### PR TITLE
Migrate test setup for Svelte 5 and add route regression coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,8 +44,20 @@ jobs:
           node-version-file: './.node-version'
       - name: Prepare dependencies
         run: npm ci
-      - name: Run checkers & linters
-        run: npm run precommit
+      - name: Run type and Svelte checks
+        run: npm run check
+        env:
+          SESSION_SECRET: ${{secrets.SESSION_SECRET}}
+          RECAPTCHA_SECRET: ${{secrets.RECAPTCHA_SECRET}}
+          RESEND_API_KEY: ${{secrets.RESEND_API_KEY}}
+      - name: Run lint
+        run: npm run lint
+        env:
+          SESSION_SECRET: ${{secrets.SESSION_SECRET}}
+          RECAPTCHA_SECRET: ${{secrets.RECAPTCHA_SECRET}}
+          RESEND_API_KEY: ${{secrets.RESEND_API_KEY}}
+      - name: Run test
+        run: npm run test
         env:
           SESSION_SECRET: ${{secrets.SESSION_SECRET}}
           RECAPTCHA_SECRET: ${{secrets.RECAPTCHA_SECRET}}

--- a/src/lib/components/__tests__/Breadcrumb.test.ts
+++ b/src/lib/components/__tests__/Breadcrumb.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
-import '@testing-library/jest-dom';
 import Breadcrumb from '../Breadcrumb.svelte';
 
 /**

--- a/src/lib/components/__tests__/Flyer.test.ts
+++ b/src/lib/components/__tests__/Flyer.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
-import '@testing-library/jest-dom';
 import Flyer from '../Flyer.svelte';
 
 /**

--- a/src/lib/components/__tests__/Meta.test.ts
+++ b/src/lib/components/__tests__/Meta.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
-import '@testing-library/jest-dom';
 import Meta from '../Meta.svelte';
 
 /**

--- a/src/lib/components/__tests__/Slider.test.ts
+++ b/src/lib/components/__tests__/Slider.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/svelte';
-import '@testing-library/jest-dom';
 import Slider from '../Slider.svelte';
 import type { Slide } from '../Slider.svelte';
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -12,7 +12,6 @@
 	import xIcon from './x-brands.svg';
 	import youtubeIcon from './youtube-brands.svg';
 	import { onDestroy } from 'svelte';
-	import type { Component } from 'svelte';
 	import { page } from '$app/stores';
 	import { browser } from '$app/environment';
 	import dayjs from 'dayjs';
@@ -27,7 +26,8 @@
 	$: headerLogo = isNyanvasEvent ? nyanvasLogo : logo;
 	$: headerLogoSp = isNyanvasEvent ? nyanvasLogoSp : logoSp;
 	$: headerAlt = isNyanvasEvent ? 'Orchestra Nyanvas Tokyoのロゴ' : 'Orchestra Canvas Tokyoのロゴ';
-	let nyanvasOverlayComponent: Component<Record<string, unknown>> | null = null;
+	let nyanvasOverlayComponent: typeof import('./nyanvas/NyanvasOverlay.svelte').default | null =
+		null;
 	let isLoadingNyanvasOverlayComponent = false;
 
 	const loadNyanvasOverlay = async () => {

--- a/src/routes/__tests__/static-pages.test.ts
+++ b/src/routes/__tests__/static-pages.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+
+import ConceptsPage from '../about/concepts/+page.svelte';
+import RecruitPage from '../recruit/+page.svelte';
+import SupportUsPage from '../support-us/+page.svelte';
+
+describe('route page regressions', () => {
+	it('renders recruit page title and breadcrumb link', () => {
+		render(RecruitPage);
+
+		expect(screen.getByRole('heading', { level: 1, name: 'recruit' })).toBeInTheDocument();
+		expect(screen.getByRole('link', { name: 'home' })).toHaveAttribute('href', '/');
+	});
+
+	it('renders concepts page title and organization image', () => {
+		render(ConceptsPage);
+
+		expect(screen.getByRole('heading', { level: 1, name: 'concepts' })).toBeInTheDocument();
+		expect(screen.getByRole('img', { name: '組織図' })).toBeInTheDocument();
+	});
+
+	it('renders support-us page title and supporter links', () => {
+		render(SupportUsPage);
+
+		expect(screen.getByRole('heading', { level: 1, name: 'ご支援のお願い' })).toBeInTheDocument();
+		expect(screen.getByRole('link', { name: 'home' })).toHaveAttribute('href', '/');
+		expect(screen.getAllByRole('link', { name: '専用フォーム' })).toHaveLength(2);
+	});
+});

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,1 +1,7 @@
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
+import { afterEach } from 'vitest';
+import { cleanup } from '@testing-library/svelte';
+
+afterEach(() => {
+	cleanup();
+});

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -7,12 +7,6 @@ const config = {
 	// for more information about preprocessors
 	preprocess: vitePreprocess(),
 
-	compilerOptions: {
-		compatibility: {
-			componentApi: 4
-		}
-	},
-
 	kit: {
 		adapter: adapter({
 			routes: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,19 +4,17 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
 	plugins: [sveltekit()],
 	test: {
-		// コンポーネントをクライアントサイドでテストするためにDOM環境を設定
 		environment: 'jsdom',
-		// テストファイルのパターンを指定
 		include: ['src/**/*.{test,spec}.{js,ts}'],
-		// テストのセットアップファイルを指定
 		setupFiles: ['src/setupTests.js'],
-		// グローバルなテスト設定
-		globals: true
+		globals: true,
+		css: true,
+		clearMocks: true,
+		restoreMocks: true
 	},
 	resolve: process.env.VITEST
 		? {
-				// Svelte 5 以降の export condition を優先しつつ既存のブラウザ条件も維持
-				conditions: ['svelte', 'browser']
+				conditions: ['browser']
 			}
 		: undefined
 });


### PR DESCRIPTION
### Motivation
- Bring the repository test setup in line with Svelte 5 + Testing Library recommendations to avoid runtime compiler/options errors and to provide a single shared test initialization. 
- Add minimal page-level regression tests so route rendering breakages are detected early during the Svelte 5 migration. 
- Make the CI enforce the migration gate by running type checks, linting and tests explicitly.

### Description
- Updated `vite.config.ts` test options for Vitest (`environment: 'jsdom'`, `setupFiles`, `globals`, `css`, `clearMocks`, `restoreMocks`) and narrowed `resolve.conditions` for test runs to `['browser']`.
- Centralized test initialization into `src/setupTests.js` using `@testing-library/jest-dom/vitest` and automatic `cleanup()` in an `afterEach` hook, and removed duplicate `jest-dom` imports from component test files.
- Removed legacy `compilerOptions.compatibility` from `svelte.config.js` and replaced uses of `Component` types with `typeof import(...).default` in `src/routes/+layout.svelte` to satisfy Svelte 5 typings.
- Added minimal regression tests `src/routes/__tests__/static-pages.test.ts` to assert key page renderings for `/recruit`, `/about/concepts` and `/support-us`.
- Updated CI workflow `.github/workflows/ci.yaml` to run `npm run check`, `npm run lint`, and `npm run test` as separate required steps.

### Testing
- Ran component-only tests with `npm run test -- src/lib/components/__tests__/*.test.ts` and they passed (component suites green).
- Ran `npm run check` (Svelte/TypeScript checks) and it passed with no errors after type adjustments.
- Ran `npm run lint` and formatting/lint checks passed after a Prettier run.
- Ran the full gate `npm run check && npm run lint && npm run test` and all checks/tests passed (52 tests total passed); Vitest printed a known `close timed out` message but test results are green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699eb8aa571c83319bc478e65931ff77)