### PR TITLE
refactor: migrate components to Svelte 5 syntax

### DIFF
--- a/src/lib/components/Breadcrumb.svelte
+++ b/src/lib/components/Breadcrumb.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	/** パンくずの各要素を定義する配列 */
-	export let segments: { title: string; lang: 'en' | 'ja'; url?: string }[] = [];
+	let { segments = [] }: { segments?: { title: string; lang: 'en' | 'ja'; url?: string }[] } =
+		$props();
 </script>
 
 <!--

--- a/src/lib/components/Flyer.svelte
+++ b/src/lib/components/Flyer.svelte
@@ -1,11 +1,19 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
 
-	export let src: string;
-	export let alt: string;
-	export let lazy: boolean = false;
-	export let width: number | undefined = undefined;
-	export let height: number | undefined = undefined;
+	let {
+		src,
+		alt,
+		lazy = false,
+		width = undefined,
+		height = undefined
+	}: {
+		src: string;
+		alt: string;
+		lazy?: boolean;
+		width?: number;
+		height?: number;
+	} = $props();
 
 	const commonOptions = [
 		['format', 'auto'],
@@ -13,7 +21,9 @@
 	] satisfies [string, string][];
 	const defaultHeight = 1920;
 
-	$: useCloudflareImages = browser && window.location.hostname === 'www.orch-canvas.tokyo';
+	const useCloudflareImages = $derived(
+		browser && window.location.hostname === 'www.orch-canvas.tokyo'
+	);
 
 	function getCloudflareSrc(src: string, options: [string, string][]): string {
 		const optionsString = options.map(([key, value]) => `${key}=${value}`).join(',');

--- a/src/lib/components/Meta.svelte
+++ b/src/lib/components/Meta.svelte
@@ -2,15 +2,17 @@
 	import { MetaTags } from 'svelte-meta-tags';
 
 	/** ページのタイトル。ルートは空文字列を指定 */
-	export let title: string;
+	let { title, canonical }: { title: string; canonical: string } = $props();
 	/** 正規URL。相対URLを指定。e.g. '/concerts/example' */
-	export let canonical: string;
 
-	$: fullTitle = title !== '' ? `${title} - Orchestra Canvas Tokyo` : 'Orchestra Canvas Tokyo';
-	$: fullCanonical =
+	const fullTitle = $derived(
+		title !== '' ? `${title} - Orchestra Canvas Tokyo` : 'Orchestra Canvas Tokyo'
+	);
+	const fullCanonical = $derived(
 		canonical === ''
 			? 'https://www.orch-canvas.tokyo'
-			: `https://www.orch-canvas.tokyo${canonical.startsWith('/') ? '' : '/'}${canonical}`;
+			: `https://www.orch-canvas.tokyo${canonical.startsWith('/') ? '' : '/'}${canonical}`
+	);
 </script>
 
 <MetaTags

--- a/src/lib/components/Slider.svelte
+++ b/src/lib/components/Slider.svelte
@@ -1,4 +1,4 @@
-<script lang="ts" context="module">
+<script lang="ts" module>
 	export type Slide = {
 		src: string;
 		alt: string;
@@ -10,7 +10,7 @@
 	import Flyer from './Flyer.svelte';
 
 	register();
-	export let slides: Slide[];
+	let { slides }: { slides: Slide[] } = $props();
 </script>
 
 <swiper-container centered-slides={true} navigation={true} effect="flip">

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -12,55 +12,60 @@
 	import facebookIcon from './facebook-brands.svg';
 	import xIcon from './x-brands.svg';
 	import youtubeIcon from './youtube-brands.svg';
-	import { onDestroy } from 'svelte';
-	import type { Component } from 'svelte';
-	import { page } from '$app/stores';
+	import type { Component, Snippet } from 'svelte';
+	import { page } from '$app/state';
 	import { browser } from '$app/environment';
 	import dayjs from 'dayjs';
 	import { afterNavigate } from '$app/navigation';
 
-	export let data: LayoutData;
+	let { data, children }: { data: LayoutData; children?: Snippet } = $props();
 
-	$: isNyanvasEvent = data.seasonalEvent?.id === 'nyanvas';
-	$: isNyanvasRoute = isNyanvasPath($page.url.pathname);
-	$: shouldShowNyanvasOverlay = isNyanvasEvent && !isNyanvasRoute;
-	$: headerHref = isNyanvasEvent ? (isNyanvasRoute ? '/' : NYANVAS_ENTRY_PATH) : '/';
-	$: headerLogo = isNyanvasEvent ? nyanvasLogo : logo;
-	$: headerLogoSp = isNyanvasEvent ? nyanvasLogoSp : logoSp;
-	$: headerAlt = isNyanvasEvent ? 'Orchestra Nyanvas Tokyoのロゴ' : 'Orchestra Canvas Tokyoのロゴ';
-	let nyanvasOverlayComponent: Component<Record<string, unknown>> | null = null;
-	let isLoadingNyanvasOverlayComponent = false;
+	const isNyanvasEvent = $derived(data.seasonalEvent?.id === 'nyanvas');
+	const isNyanvasRoute = $derived(isNyanvasPath(page.url.pathname));
+	const shouldShowNyanvasOverlay = $derived(isNyanvasEvent && !isNyanvasRoute);
+	const headerHref = $derived(isNyanvasEvent ? (isNyanvasRoute ? '/' : NYANVAS_ENTRY_PATH) : '/');
+	const headerLogo = $derived(isNyanvasEvent ? nyanvasLogo : logo);
+	const headerLogoSp = $derived(isNyanvasEvent ? nyanvasLogoSp : logoSp);
+	const headerAlt = $derived(
+		isNyanvasEvent ? 'Orchestra Nyanvas Tokyoのロゴ' : 'Orchestra Canvas Tokyoのロゴ'
+	);
+	let NyanvasOverlayComponent = $state<Component | null>(null);
+	let isLoadingNyanvasOverlayComponent = $state(false);
 
 	const loadNyanvasOverlay = async () => {
-		if (nyanvasOverlayComponent) return;
+		if (NyanvasOverlayComponent) return;
 		if (isLoadingNyanvasOverlayComponent) return;
 
 		isLoadingNyanvasOverlayComponent = true;
 
 		try {
 			const module = await import('./nyanvas/NyanvasOverlay.svelte');
-			nyanvasOverlayComponent = module.default;
+			NyanvasOverlayComponent = module.default;
 		} finally {
 			isLoadingNyanvasOverlayComponent = false;
 		}
 	};
 
-	$: if (browser && shouldShowNyanvasOverlay) {
-		void loadNyanvasOverlay();
-	}
+	$effect(() => {
+		if (browser && shouldShowNyanvasOverlay) {
+			void loadNyanvasOverlay();
+		}
+	});
 
-	const upcomingConcerts = data.concerts
-		.filter((concert) => {
-			// 開催日が未来か今日
-			return (
-				dayjs(concert.dateTime.date).isAfter(dayjs()) ||
-				dayjs(concert.dateTime.date).isSame(dayjs(), 'day')
-			);
-		})
-		.sort((a, b) => {
-			// 日付昇順
-			return dayjs(b.dateTime.date).isAfter(dayjs(a.dateTime.date)) ? -1 : 1;
-		});
+	const upcomingConcerts = $derived.by(() =>
+		data.concerts
+			.filter((concert) => {
+				// 開催日が未来か今日
+				return (
+					dayjs(concert.dateTime.date).isAfter(dayjs()) ||
+					dayjs(concert.dateTime.date).isSame(dayjs(), 'day')
+				);
+			})
+			.sort((a, b) => {
+				// 日付昇順
+				return dayjs(b.dateTime.date).isAfter(dayjs(a.dateTime.date)) ? -1 : 1;
+			})
+	);
 
 	// メニュー項目の定義
 	interface MenuItem {
@@ -72,7 +77,7 @@
 	interface HeaderMenuItem extends MenuItem {
 		children?: MenuItem[];
 	}
-	const headerMenuItems: HeaderMenuItem[] = [
+	const headerMenuItems = $derived.by((): HeaderMenuItem[] => [
 		{
 			title: 'about',
 			lang: 'en',
@@ -138,7 +143,7 @@
 			lang: 'en',
 			url: '/contact'
 		}
-	];
+	]);
 
 	const snsMenuItems: {
 		url: string;
@@ -168,17 +173,17 @@
 	];
 
 	// ハンバーガーメニュー
-	let isOpen: boolean = false;
-	$: transformX = isOpen ? '0' : '300px';
-	$: if (browser) {
-		document.body.style.overflow = isOpen ? 'hidden' : '';
-	}
+	let isOpen = $state(false);
+	const transformX = $derived(isOpen ? '0' : '300px');
 
-	// ハンバーガーメニューオープン時はスクロールしないように
-	const unsubscribe = page.subscribe(() => {
-		if (browser) document.body.style.overflow = isOpen ? 'hidden' : '';
+	$effect(() => {
+		if (!browser) return;
+
+		document.body.style.overflow = isOpen ? 'hidden' : '';
+		return () => {
+			document.body.style.overflow = '';
+		};
 	});
-	onDestroy(unsubscribe);
 
 	// 画面遷移時はハンバーガーメニューを閉じる
 	afterNavigate(() => {
@@ -186,8 +191,8 @@
 	});
 </script>
 
-{#if shouldShowNyanvasOverlay && nyanvasOverlayComponent}
-	<svelte:component this={nyanvasOverlayComponent} />
+{#if shouldShowNyanvasOverlay && NyanvasOverlayComponent}
+	<NyanvasOverlayComponent />
 {/if}
 
 <header>
@@ -275,7 +280,7 @@
 </aside>
 
 <main class=" {data.isRoot ? 'root-main' : 'non-root-main'}">
-	<slot />
+	{@render children?.()}
 
 	{#if data.isRoot}
 		<aside class="mobile-news">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,54 +8,60 @@
 	import type { Flyer as FlyerType } from '$lib/concerts/types';
 	import Flyer from '$lib/components/Flyer.svelte';
 
-	export let data: PageServerData;
+	let { data }: { data: PageServerData } = $props();
 
 	const nonRegularDisplayingConcerts: string[] = [];
 	const newConcerts: string[] = [];
-	const nonNewSlideshowItems = data.concerts
-		.filter((concert) => {
-			// 定期演奏会と直接指定した室内楽演奏会を抽出
-			// newをつける演奏会はのちに抽出
-			return (
-				(concert.type === 'regular' || nonRegularDisplayingConcerts.includes(concert.slug)) &&
-				!newConcerts.includes(concert.slug)
-			);
-		})
-		.sort((a, b) => {
-			// 日付降順
-			return dayjs(b.dateTime.date).isAfter(dayjs(a.dateTime.date)) ? 1 : -1;
-		});
-	const newSlideshowItems = data.concerts
-		.filter((concert) => {
-			// newをつける演奏会を抽出
-			return newConcerts.includes(concert.slug);
-		})
-		.sort((a, b) => {
-			// ここは開催日が近い順に：日付昇順
-			return dayjs(b.dateTime.date).isAfter(dayjs(a.dateTime.date)) ? -1 : 1;
-		});
-	const slideshowItems = [...newSlideshowItems, ...nonNewSlideshowItems]
-		.map((concert) => {
-			return {
-				title: concert.title,
-				flyers: concert.flyers,
-				slug: concert.slug,
-				isNew: newConcerts.includes(concert.slug)
-			};
-		})
-		.filter(
-			(
-				concert
-			): concert is {
-				title: string;
-				flyers: FlyerType[];
-				slug: string;
-				isNew: boolean;
-			} => {
-				// フライヤーがないものは表示しない
-				return concert.flyers !== undefined;
-			}
-		);
+	const nonNewSlideshowItems = $derived.by(() =>
+		data.concerts
+			.filter((concert) => {
+				// 定期演奏会と直接指定した室内楽演奏会を抽出
+				// newをつける演奏会はのちに抽出
+				return (
+					(concert.type === 'regular' || nonRegularDisplayingConcerts.includes(concert.slug)) &&
+					!newConcerts.includes(concert.slug)
+				);
+			})
+			.sort((a, b) => {
+				// 日付降順
+				return dayjs(b.dateTime.date).isAfter(dayjs(a.dateTime.date)) ? 1 : -1;
+			})
+	);
+	const newSlideshowItems = $derived.by(() =>
+		data.concerts
+			.filter((concert) => {
+				// newをつける演奏会を抽出
+				return newConcerts.includes(concert.slug);
+			})
+			.sort((a, b) => {
+				// ここは開催日が近い順に：日付昇順
+				return dayjs(b.dateTime.date).isAfter(dayjs(a.dateTime.date)) ? -1 : 1;
+			})
+	);
+	const slideshowItems = $derived.by(() =>
+		[...newSlideshowItems, ...nonNewSlideshowItems]
+			.map((concert) => {
+				return {
+					title: concert.title,
+					flyers: concert.flyers,
+					slug: concert.slug,
+					isNew: newConcerts.includes(concert.slug)
+				};
+			})
+			.filter(
+				(
+					concert
+				): concert is {
+					title: string;
+					flyers: FlyerType[];
+					slug: string;
+					isNew: boolean;
+				} => {
+					// フライヤーがないものは表示しない
+					return concert.flyers !== undefined;
+				}
+			)
+	);
 
 	const updatePaginationColor = (e: CustomEvent<MoveEventDetail> | undefined) => {
 		if (!e) return;
@@ -104,8 +110,8 @@
 		</SplideTrack>
 
 		<div class="splide__arrows">
-			<button class="splide__arrow splide__arrow--prev"></button>
-			<button class="splide__arrow splide__arrow--next"></button>
+			<button aria-label="前のスライド" class="splide__arrow splide__arrow--prev"></button>
+			<button aria-label="次のスライド" class="splide__arrow splide__arrow--next"></button>
 		</div>
 	</Splide>
 </div>

--- a/src/routes/about/accounting/+page.svelte
+++ b/src/routes/about/accounting/+page.svelte
@@ -3,14 +3,14 @@
 	import Breadcrumb from '$lib/components/Breadcrumb.svelte';
 	import Meta from '$lib/components/Meta.svelte';
 
-	export let data: PageServerData;
+	let { data }: { data: PageServerData } = $props();
 
-	const items: { title: string; duration: string; url: string }[] = data.reports.map(
-		(report, index) => ({
+	const items = $derived.by<{ title: string; duration: string; url: string }[]>(() =>
+		data.reports.map((report, index) => ({
 			title: `第${index + 1}期`,
 			duration: report.duration,
 			url: `/about/accounting/fiscal-year-${index + 1}`
-		})
+		}))
 	);
 </script>
 

--- a/src/routes/about/accounting/fiscal-year-[year]/+page.svelte
+++ b/src/routes/about/accounting/fiscal-year-[year]/+page.svelte
@@ -3,7 +3,7 @@
 	import Breadcrumb from '$lib/components/Breadcrumb.svelte';
 	import Meta from '$lib/components/Meta.svelte';
 
-	export let data: PageServerData;
+	let { data }: { data: PageServerData } = $props();
 </script>
 
 <Meta

--- a/src/routes/concerts/[slug]/+page.svelte
+++ b/src/routes/concerts/[slug]/+page.svelte
@@ -9,7 +9,7 @@
 	import Flyer from '$lib/components/Flyer.svelte';
 	import OpenInNewIcon from '$lib/components/OpenInNewIcon.svelte';
 
-	export let data: PageServerData;
+	let { data }: { data: PageServerData } = $props();
 </script>
 
 <Meta title={data.title} canonical="/concerts/{data.slug}" />
@@ -181,14 +181,14 @@
 
 	{#if // チケット情報があり、開催日が未来か今日だったら
 	data.ticket && data.ticket.url && (dayjs(data.dateTime.date).isAfter(dayjs()) || dayjs(data.dateTime.date).isSame(dayjs(), 'day'))}
-		<div class="spacer" />
+		<div class="spacer"></div>
 		<a href={data.ticket.url} class="full-width-button">
 			<img alt="teketロゴ" class="teket-logo" />でチケット購入
 		</a>
 	{/if}
 
 	{#if data.youtubePlaylistId}
-		<div class="spacer" />
+		<div class="spacer"></div>
 		<iframe
 			width="560"
 			height="315"

--- a/src/routes/concerts/archives/+page.svelte
+++ b/src/routes/concerts/archives/+page.svelte
@@ -9,70 +9,94 @@
 	import type { YearlyFirstConcerts } from './YearAnchors';
 	import Meta from '$lib/components/Meta.svelte';
 
-	export let data: PageServerData;
+	let { data }: { data: PageServerData } = $props();
 
 	// 開催後の定期演奏会を抽出し、開催日昇順でソートしておく
-	const regularConcerts = data.concerts
-		.filter(
-			(concert) => concert.type === 'regular' && dayjs(concert.dateTime.date).isBefore(dayjs())
-		)
-		.sort((a, b) => (dayjs(b.dateTime.date).isAfter(dayjs(a.dateTime.date)) ? -1 : 1));
+	const regularConcerts = $derived.by(() =>
+		data.concerts
+			.filter(
+				(concert) => concert.type === 'regular' && dayjs(concert.dateTime.date).isBefore(dayjs())
+			)
+			.sort((a, b) => (dayjs(b.dateTime.date).isAfter(dayjs(a.dateTime.date)) ? -1 : 1))
+	);
 	// 室内楽演奏会も同様に
-	const chamberConcerts = data.concerts
-		.filter(
-			(concert) => concert.type === 'chamber' && dayjs(concert.dateTime.date).isBefore(dayjs())
-		)
-		.sort((a, b) => (dayjs(b.dateTime.date).isAfter(dayjs(a.dateTime.date)) ? -1 : 1));
+	const chamberConcerts = $derived.by(() =>
+		data.concerts
+			.filter(
+				(concert) => concert.type === 'chamber' && dayjs(concert.dateTime.date).isBefore(dayjs())
+			)
+			.sort((a, b) => (dayjs(b.dateTime.date).isAfter(dayjs(a.dateTime.date)) ? -1 : 1))
+	);
 
-	let yearlyFirstRegularConcerts: YearlyFirstConcerts = {};
-	let currentYear = null;
-	// 各年の最初の定期演奏会を抽出
-	// 後ほど、アンカーリンクを張るのに使う
-	for (let concert of regularConcerts) {
-		const concertYear = dayjs(concert.dateTime.date).year();
-		if (concertYear !== currentYear) {
-			currentYear = concertYear;
-			yearlyFirstRegularConcerts[concert.slug] = concertYear;
-		}
-	}
+	const yearlyFirstRegularConcerts = $derived.by((): YearlyFirstConcerts => {
+		const yearlyFirstConcerts: YearlyFirstConcerts = {};
+		let currentYear: number | null = null;
 
-	let yearlyFirstChamberConcerts: YearlyFirstConcerts = {};
-	currentYear = null;
-	// 各年の最初の室内楽演奏会を抽出
-	for (let concert of chamberConcerts) {
-		const concertYear = dayjs(concert.dateTime.date).year();
-		if (concertYear !== currentYear) {
-			currentYear = concertYear;
-			yearlyFirstChamberConcerts[concert.slug] = concertYear;
+		// 各年の最初の定期演奏会を抽出
+		// 後ほど、アンカーリンクを張るのに使う
+		for (const concert of regularConcerts) {
+			const concertYear = dayjs(concert.dateTime.date).year();
+			if (concertYear !== currentYear) {
+				currentYear = concertYear;
+				yearlyFirstConcerts[concert.slug] = concertYear;
+			}
 		}
-	}
+
+		return yearlyFirstConcerts;
+	});
+
+	const yearlyFirstChamberConcerts = $derived.by((): YearlyFirstConcerts => {
+		const yearlyFirstConcerts: YearlyFirstConcerts = {};
+		let currentYear: number | null = null;
+
+		// 各年の最初の室内楽演奏会を抽出
+		for (const concert of chamberConcerts) {
+			const concertYear = dayjs(concert.dateTime.date).year();
+			if (concertYear !== currentYear) {
+				currentYear = concertYear;
+				yearlyFirstConcerts[concert.slug] = concertYear;
+			}
+		}
+
+		return yearlyFirstConcerts;
+	});
 
 	onMount(() => {
-		const anchorLinks = document.querySelectorAll('a[href^="#"]');
+		const anchorLinks = Array.from(document.querySelectorAll<HTMLAnchorElement>('a[href^="#"]'));
 		const offset = 100; // アンカーリンクへの遷移の際、上部に設けたいマージンの値
+
+		const onAnchorClick = (e: MouseEvent) => {
+			e.preventDefault();
+
+			const link = e.currentTarget as HTMLAnchorElement | null;
+			const targetId = link?.getAttribute('href');
+			if (targetId === null || targetId === undefined) return;
+
+			const targetElement = document.querySelector(targetId);
+			if (targetElement === null) return;
+
+			const targetPosition = window.scrollY + targetElement.getBoundingClientRect().top;
+			window.scrollTo({
+				top: targetPosition - offset,
+				behavior: 'smooth'
+			});
+		};
+
 		anchorLinks.forEach((link) => {
 			// スムーズに遷移するためのおまじない
-			link.addEventListener('click', function (e) {
-				e.preventDefault();
-
-				const targetId = link.getAttribute('href');
-				if (targetId === null) return;
-
-				const targetElement = document.querySelector(targetId);
-				if (targetElement === null) return;
-
-				const targetPosition = window.scrollY + targetElement.getBoundingClientRect().top;
-				window.scrollTo({
-					top: targetPosition - offset,
-					behavior: 'smooth'
-				});
-			});
+			link.addEventListener('click', onAnchorClick);
 		});
+
+		return () => {
+			anchorLinks.forEach((link) => {
+				link.removeEventListener('click', onAnchorClick);
+			});
+		};
 	});
 
 	// ページ遷移前後で定期・室内楽の選択状態が保持されるようにする
 	// SvelteKitのSnapshotを用いており、これは内部的にはSessionStorage
-	let checkedConcertType: string = 'regular';
+	let checkedConcertType = $state<string>('regular');
 	export const snapshot: Snapshot<string> = {
 		capture: () => checkedConcertType,
 		restore: (value) => (checkedConcertType = value)

--- a/src/routes/concerts/archives/Concert.svelte
+++ b/src/routes/concerts/archives/Concert.svelte
@@ -9,9 +9,14 @@
 	import youtubeLogo from './yt_logo_mono_dark.png';
 
 	/** このコンポーネントが表示する演奏会 */
-	export let concert: Concert;
+	let {
+		concert,
+		yearlyFirstConcert
+	}: {
+		concert: Concert;
+		yearlyFirstConcert: YearlyFirstConcerts;
+	} = $props();
 	/** アンカーリンクを張る、各年最初の演奏会の情報をまとめたオブジェクト */
-	export let yearlyFirstConcert: YearlyFirstConcerts;
 </script>
 
 <!--
@@ -203,7 +208,7 @@
 		}
 	}
 
-	:is(picture):has(.flyer) {
+	.flyer-container {
 		line-height: 0;
 	}
 

--- a/src/routes/concerts/archives/YearAnchors.svelte
+++ b/src/routes/concerts/archives/YearAnchors.svelte
@@ -3,9 +3,14 @@
 	import type { YearlyFirstConcerts } from './YearAnchors';
 
 	/** 年と対応する演奏会の一覧 */
-	export let yearlyFirstConcerts: YearlyFirstConcerts;
+	let {
+		yearlyFirstConcerts,
+		concertType
+	}: {
+		yearlyFirstConcerts: YearlyFirstConcerts;
+		concertType: ConcertType;
+	} = $props();
 	/** 演奏会種別 */
-	export let concertType: ConcertType;
 </script>
 
 <!--

--- a/src/routes/contact/+page.svelte
+++ b/src/routes/contact/+page.svelte
@@ -3,7 +3,7 @@
 	import Breadcrumb from '$lib/components/Breadcrumb.svelte';
 	import Meta from '$lib/components/Meta.svelte';
 
-	export let data: PageServerData;
+	let { data }: { data: PageServerData } = $props();
 </script>
 
 <Meta title="Contact" canonical="/contact" />
@@ -61,7 +61,7 @@
 		height="635"
 		frameborder="0"
 		title="お問い合わせフォーム"
-	/>
+	></iframe>
 </article>
 
 <style>

--- a/src/routes/news/+page.svelte
+++ b/src/routes/news/+page.svelte
@@ -4,17 +4,21 @@
 	import dayjs from 'dayjs';
 	import Meta from '$lib/components/Meta.svelte';
 
-	export let data: PageServerData;
+	let { data }: { data: PageServerData } = $props();
 	const sliceNumber = 10; //１ページに表示するnewsの数
 
-	const newsItems = data.newsItems
-		.sort((a, b) => (dayjs(b.date).isAfter(dayjs(a.date)) ? -1 : 1)) // 日付降順に並び替え
-		.reverse();
-	const pageLength = Math.ceil(newsItems.length / sliceNumber); // ページ数
-	const separatedNewsItems = new Array(pageLength) // slice_number個ずつに切り分け
-		.fill(null)
-		.map((_, i) => newsItems.slice(i * sliceNumber, (i + 1) * sliceNumber));
-	let page = 0;
+	const newsItems = $derived.by(() =>
+		[...data.newsItems]
+			.sort((a, b) => (dayjs(b.date).isAfter(dayjs(a.date)) ? -1 : 1)) // 日付降順に並び替え
+			.reverse()
+	);
+	const pageLength = $derived(Math.ceil(newsItems.length / sliceNumber)); // ページ数
+	const separatedNewsItems = $derived.by(() =>
+		new Array(pageLength) // slice_number個ずつに切り分け
+			.fill(null)
+			.map((_, i) => newsItems.slice(i * sliceNumber, (i + 1) * sliceNumber))
+	);
+	let page = $state(0);
 </script>
 
 <Meta title="News" canonical="/news" />
@@ -51,7 +55,7 @@
 		<div class="page-button">
 			{#if page != 0}
 				<button
-					on:click={() => {
+					onclick={() => {
 						if (page > 0) page -= 1;
 					}}
 				>
@@ -65,7 +69,7 @@
 		<div class="page-button right">
 			{#if page != pageLength - 1}
 				<button
-					on:click={() => {
+					onclick={() => {
 						if (page < pageLength - 1) page += 1;
 					}}
 				>

--- a/src/routes/nyanvas/20250401/+page.svelte
+++ b/src/routes/nyanvas/20250401/+page.svelte
@@ -22,7 +22,7 @@
 <div class="container">
 	<article>
 		<img src={oldLogo} alt="Orchestra Canvas Tokyo" />
-		<span class="arrow" />
+		<span class="arrow"></span>
 		<section>
 			<h1>
 				<img src={logo} alt="Orchestra Nyanvas Tokyo" />

--- a/src/routes/nyanvas/20260222/+page.svelte
+++ b/src/routes/nyanvas/20260222/+page.svelte
@@ -22,7 +22,7 @@
 <div class="container">
 	<article>
 		<img src={oldLogo} alt="Orchestra Canvas Tokyo" />
-		<span class="arrow" />
+		<span class="arrow"></span>
 		<section>
 			<h1>
 				<img src={logo} alt="Orchestra Nyanvas Tokyo" />

--- a/src/routes/nyanvas/NyanvasOverlay.svelte
+++ b/src/routes/nyanvas/NyanvasOverlay.svelte
@@ -5,7 +5,7 @@
 
 	let pawEngine: PawEngine | null = null;
 	let deviceMotionController: DeviceMotionController | null = null;
-	let showPermissionToast = false;
+	let showPermissionToast = $state(false);
 
 	const updatePermissionStatus = (permitted: boolean) => {
 		showPermissionToast = !permitted;
@@ -55,11 +55,11 @@
 	};
 </script>
 
-<svelte:window on:click={onclick} on:devicemotion={ondevicemotion} on:resize={onresize} />
+<svelte:window {onclick} {ondevicemotion} {onresize} />
 
 <div id="permission-toast" class="toast" class:show={showPermissionToast}>
 	<p>ぜひ、加速度センサー付きでご覧ください！</p>
-	<button on:click={onclickGrantPermission}>進む</button>
+	<button onclick={onclickGrantPermission}>進む</button>
 </div>
 
 <style>

--- a/src/routes/support-us/+page.svelte
+++ b/src/routes/support-us/+page.svelte
@@ -474,8 +474,7 @@
 	thead {
 		border-bottom: 2px solid;
 	}
-	thead tr th:first-child,
-	thead tr td:first-child {
+	thead tr th:first-child {
 		border-right: 2px solid;
 	}
 	table ul {


### PR DESCRIPTION
## Summary
- migrate component props, derived state, and effects to Svelte 5 syntax
- move the root layout to `$app/state`, `children`, and runes-based state/effects
- clean up remaining Svelte warnings found during `check`/`build`

## Testing
- npm run check
- npm run lint
- npm test
- npm run build

## Notes
- rebased onto `main` after #194 was merged
- subagent review completed before commit with no blocking findings