### PR TITLE
[codex] Add playlist for regular 15

### DIFF
--- a/src/lib/concerts/regular/regular15.ts
+++ b/src/lib/concerts/regular/regular15.ts
@@ -54,7 +54,7 @@ export const concert: Concert = {
 		description: '全席指定 1,000円',
 		url: 'https://teket.jp/1776/52506?uid=hp'
 	},
-	showLinkToProgramNote: true
+	showLinkToProgramNote: true,
 	// cspell: disable-next-line
-	// youtubePlaylistId: '●'
+	youtubePlaylistId: 'PLlsZL5V_BM_FneLkcYOuRffvTsGX73lec'
 };


### PR DESCRIPTION
## What changed
- Added the YouTube playlist ID to the 第15回定期演奏会 data so the concert page shows the embedded playlist

## Why
- The page needed the provided playlist to be published on the concert detail page

## Impact
- Visitors to the 第15回定期演奏会 page can now watch the associated YouTube playlist directly from the page

## Validation
- `npm run check`
- `prettier --check src/lib/concerts/regular/regular15.ts`
- pre-commit hook on commit:
  - `npm run check`
  - `npm run lint:prettier`
  - `npm run lint:eslint`
  - `npm run test`
- Subagent review: no findings