### PR TITLE
[codex] Improve organization stats Slack summary

### DIFF
--- a/.github/workflows/post_organization_stats_slack_summary.ts
+++ b/.github/workflows/post_organization_stats_slack_summary.ts
@@ -1,10 +1,15 @@
 import {
 	createOrganizationStatsErrorSummary,
-	formatOrganizationStatsSlackSummary,
+	formatOrganizationStatsSlackPayload,
 	type OrganizationStatsUpdateSummary
 } from '../../src/lib/organizationStatsUpdateSummary.ts';
 
 const SLACK_WEBHOOK_URL = process.env.SLACK_ORGANIZATION_STATS_WEBHOOK_URL;
+
+const writeError = async (message: string): Promise<void> =>
+	new Promise((resolve) => {
+		process.stderr.write(`${message}\n`, () => resolve());
+	});
 
 const parseSummary = (): OrganizationStatsUpdateSummary => {
 	const rawSummary = process.env.ORGANIZATION_STATS_UPDATE_SUMMARY;
@@ -48,7 +53,7 @@ const postSlackSummary = async (): Promise<void> => {
 	}
 
 	const summary = parseSummary();
-	const text = formatOrganizationStatsSlackSummary(summary, {
+	const payload = formatOrganizationStatsSlackPayload(summary, {
 		failedSteps: getFailedSteps(),
 		runUrl: getRunUrl(),
 		workflowStatus: process.env.WORKFLOW_JOB_STATUS
@@ -58,7 +63,7 @@ const postSlackSummary = async (): Promise<void> => {
 		headers: {
 			'content-type': 'application/json'
 		},
-		body: JSON.stringify({ text })
+		body: JSON.stringify(payload)
 	});
 
 	if (!response.ok) {
@@ -69,8 +74,8 @@ const postSlackSummary = async (): Promise<void> => {
 	}
 };
 
-postSlackSummary().catch((error: unknown) => {
+postSlackSummary().catch(async (error: unknown) => {
 	const message = error instanceof Error ? error.message : String(error);
-	console.error(message);
+	await writeError(message);
 	process.exitCode = 1;
 });

--- a/.github/workflows/update_organization_stats.ts
+++ b/.github/workflows/update_organization_stats.ts
@@ -33,6 +33,11 @@ const MAX_ALLOWED_ATTENDANCE_INCREASE = Number.parseInt(
 );
 const ORGANIZATION_STATS_PATH = 'src/lib/organizationStats.json';
 
+const writeError = async (message: string): Promise<void> =>
+	new Promise((resolve) => {
+		process.stderr.write(`${message}\n`, () => resolve());
+	});
+
 const appendGitHubEnv = async (key: string, value: string): Promise<void> => {
 	if (!GITHUB_ENV) {
 		return;
@@ -174,7 +179,7 @@ const updateOrganizationStats = async (): Promise<void> => {
 
 updateOrganizationStats().catch(async (error: unknown) => {
 	const message = error instanceof Error ? error.message : String(error);
-	console.error(message);
+	await writeError(message);
 
 	if (GITHUB_ENV) {
 		await appendGitHubEnv('SHOULD_COMMIT', 'false');

--- a/src/lib/__tests__/organizationStatsUpdateSummary.test.ts
+++ b/src/lib/__tests__/organizationStatsUpdateSummary.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, it } from 'vitest';
 
 import {
 	createOrganizationStatsErrorSummary,
+	formatOrganizationStatsSlackPayload,
 	formatOrganizationStatsSlackSummary,
 	summarizeOrganizationStatsUpdate
 } from '../organizationStatsUpdateSummary';
 
 describe('organization stats update summary', () => {
+	const generatedAt = new Date('2026-04-10T02:50:24.893Z');
+
 	it('marks raw numeric changes as updated even when display buckets stay the same', () => {
 		const summary = summarizeOrganizationStatsUpdate(
 			{
@@ -55,7 +58,7 @@ describe('organization stats update summary', () => {
 	});
 
 	it('formats updated summaries with diffs and persistence decisions', () => {
-		const text = formatOrganizationStatsSlackSummary(
+		const payload = formatOrganizationStatsSlackPayload(
 			summarizeOrganizationStatsUpdate(
 				{
 					totalAttendance: 7867,
@@ -70,18 +73,78 @@ describe('organization stats update summary', () => {
 				}
 			),
 			{
+				generatedAt,
 				runUrl: 'https://example.com/runs/1'
 			}
 		);
 
-		expect(text).toContain('結果: 更新あり (3項目)');
-		expect(text).toContain('累計来場者数: 7,867 -> 8,001 (+134)');
-		expect(text).toContain('公開用JSON: 更新対象あり（表示値差分あり）');
-		expect(text).toContain('Run: https://example.com/runs/1');
+		expect(payload.text).toContain('団体情報統計 更新サマリー | 2026-04-09 JST');
+		expect(payload.text).toContain('生成: 2026-04-10T02:50:24.893Z');
+		expect(payload.text).toContain('サマリー: 3件更新');
+		expect(payload.text).toContain('- 🟡 YT総再生回数 6,704,321回 (+96,431)');
+		expect(payload.text).toContain('- 🟡 YT登録者数 16,050人 (+1,050)');
+		expect(payload.text).toContain('- 🟡 累計来場者数 8,001名 (+134)');
+		expect(payload.text).toContain('公開用JSON: 更新対象あり（表示値差分あり）');
+		expect(payload.text).toContain('<https://example.com/runs/1|実行ログ>');
+		expect(payload.blocks.slice(0, 4)).toMatchObject([
+			{
+				type: 'section',
+				text: {
+					type: 'mrkdwn',
+					text: '*団体情報統計 更新サマリー | 2026-04-09 JST*'
+				}
+			},
+			{
+				type: 'context',
+				elements: [
+					{
+						type: 'mrkdwn',
+						text: '生成: 2026-04-10T02:50:24.893Z'
+					}
+				]
+			},
+			{
+				type: 'divider'
+			},
+			{
+				type: 'section',
+				text: {
+					type: 'mrkdwn',
+					text: '*サマリー: 3件更新*'
+				}
+			}
+		]);
+	});
+
+	it('formats no-change summaries with current metric values', () => {
+		const text = formatOrganizationStatsSlackSummary(
+			summarizeOrganizationStatsUpdate(
+				{
+					totalAttendance: 7867,
+					youtubeSubscriberCount: 15000,
+					youtubeTotalViewCount: 6607890,
+					youtubeSubscriberCountVerified: false
+				},
+				{
+					totalAttendance: 7867,
+					youtubeSubscriberCount: 15000,
+					youtubeTotalViewCount: 6607890
+				}
+			),
+			{
+				generatedAt
+			}
+		);
+
+		expect(text).toContain('サマリー: 更新なし');
+		expect(text).toContain('- 🟢 YT総再生回数 6,607,890回');
+		expect(text).toContain('- 🟢 YT登録者数 15,000人');
+		expect(text).toContain('- 🟢 累計来場者数 7,867名');
+		expect(text).toContain('公開用JSON: 更新対象あり（登録者数検証フラグを確定）');
 	});
 
 	it('formats workflow failures as errors while preserving fetched values', () => {
-		const text = formatOrganizationStatsSlackSummary(
+		const payload = formatOrganizationStatsSlackPayload(
 			summarizeOrganizationStatsUpdate(
 				{
 					totalAttendance: 7867,
@@ -96,22 +159,27 @@ describe('organization stats update summary', () => {
 				}
 			),
 			{
+				generatedAt,
 				workflowStatus: 'failure',
 				failedSteps: ['Create or update main PR']
 			}
 		);
 
-		expect(text).toContain('結果: エラー');
-		expect(text).toContain('Create or update main PR');
-		expect(text).toContain('取得できた差分:');
+		expect(payload.text).toContain('サマリー: エラー');
+		expect(payload.text).toContain('Create or update main PR');
+		expect(payload.text).toContain('- 🟡 累計来場者数 7,868名 (+1)');
 	});
 
 	it('formats update errors directly', () => {
-		const text = formatOrganizationStatsSlackSummary(
-			createOrganizationStatsErrorSummary('Attendance CSV is empty.')
+		const payload = formatOrganizationStatsSlackPayload(
+			createOrganizationStatsErrorSummary('Attendance CSV is empty.'),
+			{
+				generatedAt
+			}
 		);
 
-		expect(text).toContain('結果: エラー');
-		expect(text).toContain('Attendance CSV is empty.');
+		expect(payload.text).toContain('サマリー: エラー');
+		expect(payload.text).toContain('Attendance CSV is empty.');
+		expect(payload.blocks).toHaveLength(4);
 	});
 });

--- a/src/lib/__tests__/organizationStatsWorkflowScripts.test.ts
+++ b/src/lib/__tests__/organizationStatsWorkflowScripts.test.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { promisify } from 'node:util';
 import { fileURLToPath } from 'node:url';
@@ -9,15 +10,12 @@ const execFileAsync = promisify(execFile);
 const testDirectory = dirname(fileURLToPath(import.meta.url));
 const repositoryRoot = resolve(testDirectory, '../../..');
 
-const runWorkflowScript = async (scriptPath: string): Promise<{ code: number; stderr: string }> => {
-	const env = { ...process.env };
-
-	delete env.ATTENDANCE_CSV_URL;
-	delete env.CHANNEL_ID;
-	delete env.GITHUB_ENV;
-	delete env.ORGANIZATION_STATS_UPDATE_SUMMARY;
-	delete env.SLACK_ORGANIZATION_STATS_WEBHOOK_URL;
-	delete env.YOUTUBE_API_KEY;
+const runWorkflowScript = async (scriptPath: string): Promise<{ code: number; output: string }> => {
+	const env = {
+		HOME: process.env.HOME,
+		PATH: process.env.PATH,
+		TMPDIR: process.env.TMPDIR
+	};
 
 	try {
 		await execFileAsync(process.execPath, [scriptPath], {
@@ -25,36 +23,46 @@ const runWorkflowScript = async (scriptPath: string): Promise<{ code: number; st
 			env
 		});
 
-		return { code: 0, stderr: '' };
+		return { code: 0, output: '' };
 	} catch (error) {
-		const { code = 1, stderr = '' } = error as {
+		const {
+			code = 1,
+			stderr = '',
+			stdout = ''
+		} = error as {
 			code?: number;
+			stdout?: string;
 			stderr?: string;
 		};
 
 		return {
 			code,
-			stderr
+			output: `${stdout}${stderr}`
 		};
 	}
 };
 
+const expectWorkflowScriptLoads = async (scriptPath: string, expectedGuard: string) => {
+	const result = await runWorkflowScript(scriptPath);
+	const scriptSource = readFileSync(resolve(repositoryRoot, scriptPath), 'utf-8');
+
+	expect(result.code).toBe(1);
+	expect(result.output).not.toContain('ERR_MODULE_NOT_FOUND');
+	expect(scriptSource).toContain(expectedGuard);
+};
+
 describe('organization stats workflow scripts', () => {
 	it('loads update_organization_stats.ts with native Node resolution', async () => {
-		const result = await runWorkflowScript('.github/workflows/update_organization_stats.ts');
-
-		expect(result.code).toBe(1);
-		expect(result.stderr).toContain('Missing CHANNEL_ID, YOUTUBE_API_KEY, or ATTENDANCE_CSV_URL.');
-		expect(result.stderr).not.toContain('ERR_MODULE_NOT_FOUND');
+		await expectWorkflowScriptLoads(
+			'.github/workflows/update_organization_stats.ts',
+			'Missing CHANNEL_ID, YOUTUBE_API_KEY, or ATTENDANCE_CSV_URL.'
+		);
 	});
 
 	it('loads post_organization_stats_slack_summary.ts with native Node resolution', async () => {
-		const result = await runWorkflowScript(
-			'.github/workflows/post_organization_stats_slack_summary.ts'
+		await expectWorkflowScriptLoads(
+			'.github/workflows/post_organization_stats_slack_summary.ts',
+			'Missing SLACK_ORGANIZATION_STATS_WEBHOOK_URL.'
 		);
-
-		expect(result.code).toBe(1);
-		expect(result.stderr).toContain('Missing SLACK_ORGANIZATION_STATS_WEBHOOK_URL.');
-		expect(result.stderr).not.toContain('ERR_MODULE_NOT_FOUND');
 	});
 });

--- a/src/lib/organizationStatsUpdateSummary.ts
+++ b/src/lib/organizationStatsUpdateSummary.ts
@@ -38,8 +38,36 @@ export type OrganizationStatsUpdateSummary =
 
 type OrganizationStatsSlackSummaryOptions = {
 	failedSteps?: string[];
+	generatedAt?: Date;
 	runUrl?: string;
+	summaryDate?: string;
 	workflowStatus?: string;
+};
+
+type SlackMarkdownTextObject = {
+	type: 'mrkdwn';
+	text: string;
+};
+
+type SlackSectionBlock = {
+	type: 'section';
+	text: SlackMarkdownTextObject;
+};
+
+type SlackContextBlock = {
+	type: 'context';
+	elements: SlackMarkdownTextObject[];
+};
+
+type SlackDividerBlock = {
+	type: 'divider';
+};
+
+export type OrganizationStatsSlackBlock = SlackSectionBlock | SlackContextBlock | SlackDividerBlock;
+
+export type OrganizationStatsSlackPayload = {
+	text: string;
+	blocks: OrganizationStatsSlackBlock[];
 };
 
 const fieldLabels = {
@@ -55,6 +83,27 @@ const displayFormatters = {
 } satisfies Record<OrganizationStatsFieldKey, (value: number) => string>;
 
 const organizationStatsKeys = Object.keys(fieldLabels) as OrganizationStatsFieldKey[];
+
+const slackMetricFieldOrder = [
+	'youtubeTotalViewCount',
+	'youtubeSubscriberCount',
+	'totalAttendance'
+] satisfies OrganizationStatsFieldKey[];
+
+const slackMetricLabels = {
+	totalAttendance: '累計来場者数',
+	youtubeSubscriberCount: 'YT登録者数',
+	youtubeTotalViewCount: 'YT総再生回数'
+} satisfies Record<OrganizationStatsFieldKey, string>;
+
+const slackMetricUnits = {
+	totalAttendance: '名',
+	youtubeSubscriberCount: '人',
+	youtubeTotalViewCount: '回'
+} satisfies Record<OrganizationStatsFieldKey, string>;
+
+const DAY_IN_MILLISECONDS = 24 * 60 * 60 * 1000;
+const JST_OFFSET_MILLISECONDS = 9 * 60 * 60 * 1000;
 
 const formatRawInteger = (value: number): string => value.toLocaleString('ja-JP');
 
@@ -82,11 +131,96 @@ const formatPersistDecision = (
 	return `公開用JSON: 更新対象あり（${reasons.join(' / ')}）`;
 };
 
-const formatChangedField = (field: OrganizationStatsFieldSummary): string =>
-	`- ${field.label}: ${formatRawInteger(field.previousValue)} -> ${formatRawInteger(field.nextValue)} (${formatSignedInteger(field.delta)}) / 表示: ${field.previousDisplayValue} -> ${field.nextDisplayValue}`;
+const formatJstDate = (date: Date): string =>
+	new Date(date.getTime() + JST_OFFSET_MILLISECONDS).toISOString().slice(0, 10);
 
-const formatCurrentField = (field: OrganizationStatsFieldSummary): string =>
-	`- ${field.label}: ${formatRawInteger(field.nextValue)} / 表示: ${field.nextDisplayValue}`;
+const getDefaultSummaryDate = (generatedAt: Date): string =>
+	formatJstDate(new Date(generatedAt.getTime() - DAY_IN_MILLISECONDS));
+
+const escapeSlackText = (value: string): string =>
+	value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+
+const createMarkdownText = (text: string): SlackMarkdownTextObject => ({
+	type: 'mrkdwn',
+	text
+});
+
+const createSectionBlock = (text: string): SlackSectionBlock => ({
+	type: 'section',
+	text: createMarkdownText(text)
+});
+
+const createContextBlock = (text: string): SlackContextBlock => ({
+	type: 'context',
+	elements: [createMarkdownText(text)]
+});
+
+const getOrderedSlackFields = (
+	summary: Extract<OrganizationStatsUpdateSummary, { status: 'updated' | 'no_change' }>
+): OrganizationStatsFieldSummary[] =>
+	slackMetricFieldOrder.map((key) => {
+		const field = summary.fields.find((summaryField) => summaryField.key === key);
+
+		if (!field) {
+			throw new Error(`Missing organization stats summary field: ${key}`);
+		}
+
+		return field;
+	});
+
+const formatSlackMetricField = (field: OrganizationStatsFieldSummary): string => {
+	const delta = field.changed ? ` (${formatSignedInteger(field.delta)})` : '';
+
+	return `- ${field.changed ? '🟡' : '🟢'} ${slackMetricLabels[field.key]} ${formatRawInteger(field.nextValue)}${slackMetricUnits[field.key]}${delta}`;
+};
+
+const formatFailedStepsDetail = (failedSteps: string[]): string =>
+	failedSteps.length > 0
+		? `GitHub Actions の後続 step に失敗しました (${failedSteps.join(', ')})`
+		: 'GitHub Actions の実行に失敗しました。';
+
+const getSlackSummaryLabel = (
+	summary: OrganizationStatsUpdateSummary,
+	options: Pick<OrganizationStatsSlackSummaryOptions, 'workflowStatus'>
+): string => {
+	if (summary.status === 'error' || options.workflowStatus === 'failure') {
+		return 'エラー';
+	}
+
+	if (summary.status === 'updated') {
+		return `${summary.fields.filter((field) => field.changed).length}件更新`;
+	}
+
+	return '更新なし';
+};
+
+const createSlackSummaryParts = (
+	summary: OrganizationStatsUpdateSummary,
+	options: OrganizationStatsSlackSummaryOptions
+) => {
+	const generatedAt = options.generatedAt ?? new Date();
+	const failedSteps = options.failedSteps?.filter((step) => step !== '') ?? [];
+	const title = `団体情報統計 更新サマリー | ${options.summaryDate ?? getDefaultSummaryDate(generatedAt)} JST`;
+	const summaryLines = [`*サマリー: ${getSlackSummaryLabel(summary, options)}*`];
+	const metricRows =
+		summary.status === 'error' ? [] : getOrderedSlackFields(summary).map(formatSlackMetricField);
+	const persistDecision = summary.status === 'error' ? undefined : formatPersistDecision(summary);
+
+	if (summary.status === 'error') {
+		summaryLines.push(`詳細: ${escapeSlackText(summary.errorMessage)}`);
+	} else if (options.workflowStatus === 'failure') {
+		summaryLines.push(`詳細: ${escapeSlackText(formatFailedStepsDetail(failedSteps))}`);
+	}
+
+	return {
+		title,
+		generatedAtLine: `生成: ${generatedAt.toISOString()}`,
+		summaryText: summaryLines.join('\n'),
+		metricRows,
+		persistDecision,
+		runLink: options.runUrl ? `<${options.runUrl}|実行ログ>` : undefined
+	};
+};
 
 export const createOrganizationStatsErrorSummary = (
 	errorMessage: string
@@ -140,55 +274,50 @@ export const formatOrganizationStatsSlackSummary = (
 	summary: OrganizationStatsUpdateSummary,
 	options: OrganizationStatsSlackSummaryOptions = {}
 ): string => {
-	const lines = ['団体情報の統計更新サマリー'];
-	const failedSteps = options.failedSteps?.filter((step) => step !== '') ?? [];
+	const parts = createSlackSummaryParts(summary, options);
+	const lines = [parts.title, parts.generatedAtLine, '---', parts.summaryText.replaceAll('*', '')];
 
-	if (summary.status === 'error') {
-		lines.push('結果: エラー');
-		lines.push(`詳細: ${summary.errorMessage}`);
-	} else if (options.workflowStatus === 'failure') {
-		lines.push('結果: エラー');
-		lines.push(
-			failedSteps.length > 0
-				? `詳細: GitHub Actions の後続 step に失敗しました (${failedSteps.join(', ')})`
-				: '詳細: GitHub Actions の実行に失敗しました。'
-		);
-
-		if (summary.status === 'updated') {
-			lines.push('取得できた差分:');
-			lines.push(...summary.fields.filter((field) => field.changed).map(formatChangedField));
-		} else {
-			lines.push('取得できた現在値:');
-			lines.push(...summary.fields.map(formatCurrentField));
-		}
-
-		lines.push(formatPersistDecision(summary));
-	} else if (summary.status === 'updated') {
-		const changedFields = summary.fields.filter((field) => field.changed);
-		const unchangedFieldLabels = summary.fields
-			.filter((field) => !field.changed)
-			.map((field) => field.label);
-
-		lines.push(`結果: 更新あり (${changedFields.length}項目)`);
-		lines.push('差分:');
-		lines.push(...changedFields.map(formatChangedField));
-
-		if (unchangedFieldLabels.length > 0) {
-			lines.push(`変更なし: ${unchangedFieldLabels.join(', ')}`);
-		}
-
-		lines.push(formatPersistDecision(summary));
-	} else {
-		lines.push('結果: 更新なし');
-		lines.push(`全${summary.fields.length}項目に差分はありません。`);
-		lines.push('現在値:');
-		lines.push(...summary.fields.map(formatCurrentField));
-		lines.push(formatPersistDecision(summary));
+	if (parts.metricRows.length > 0) {
+		lines.push(...parts.metricRows);
 	}
 
-	if (options.runUrl) {
-		lines.push(`Run: ${options.runUrl}`);
+	if (parts.persistDecision) {
+		lines.push(parts.persistDecision);
+	}
+
+	if (parts.runLink) {
+		lines.push(parts.runLink);
 	}
 
 	return lines.join('\n');
+};
+
+export const formatOrganizationStatsSlackPayload = (
+	summary: OrganizationStatsUpdateSummary,
+	options: OrganizationStatsSlackSummaryOptions = {}
+): OrganizationStatsSlackPayload => {
+	const parts = createSlackSummaryParts(summary, options);
+	const blocks: OrganizationStatsSlackBlock[] = [
+		createSectionBlock(`*${parts.title}*`),
+		createContextBlock(parts.generatedAtLine),
+		{ type: 'divider' },
+		createSectionBlock(parts.summaryText)
+	];
+
+	if (parts.metricRows.length > 0) {
+		blocks.push(createSectionBlock(parts.metricRows.join('\n')));
+	}
+
+	if (parts.persistDecision) {
+		blocks.push(createContextBlock(parts.persistDecision));
+	}
+
+	if (parts.runLink) {
+		blocks.push(createSectionBlock(parts.runLink));
+	}
+
+	return {
+		text: formatOrganizationStatsSlackSummary(summary, options),
+		blocks
+	};
 };


### PR DESCRIPTION
## Summary
- add a Slack Block Kit payload for the organization stats monitoring summary while preserving the top-level text fallback
- include the title date, generated timestamp, divider, bold summary, metric rows, JSON persistence note, and execution log link
- keep workflow failure and direct update error notifications readable in the new block format
- stabilize the workflow-script native-resolution test harness for parallel Vitest runs

## Validation
- `npm test -- --run src/lib/__tests__/organizationStatsUpdateSummary.test.ts src/lib/__tests__/organizationStatsWorkflowScripts.test.ts`
- `npm test`
- `npm run check` (0 errors, 3 existing warnings in unrelated Svelte files)
- `npm run lint`
- `npm run build` (same existing Svelte warnings)
- pre-commit hook: `npm run check && npm run lint:prettier && npm run lint:eslint && npm run test`

Closes #207