### PR TITLE
[codex] automate organization stats promotion

### DIFF
--- a/.github/workflows/create_production_release_pr.yaml
+++ b/.github/workflows/create_production_release_pr.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - src/lib/organizationStats.json
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/fetch_view_count.yaml
+++ b/.github/workflows/fetch_view_count.yaml
@@ -33,10 +33,12 @@ jobs:
         if: github.ref_name == github.event.repository.default_branch
         run: |
           git fetch origin main production
-          echo "PRE_UPDATE_MAIN_SHA=$(git rev-parse origin/main)" >> "$GITHUB_ENV"
-          echo "PRE_UPDATE_MAIN_TREE_SHA=$(git rev-parse origin/main^{tree})" >> "$GITHUB_ENV"
-          echo "PRE_UPDATE_PRODUCTION_SHA=$(git rev-parse origin/production)" >> "$GITHUB_ENV"
-          echo "PRE_UPDATE_PRODUCTION_TREE_SHA=$(git rev-parse origin/production^{tree})" >> "$GITHUB_ENV"
+          {
+            echo "PRE_UPDATE_MAIN_SHA=$(git rev-parse origin/main)"
+            echo "PRE_UPDATE_MAIN_TREE_SHA=$(git rev-parse 'origin/main^{tree}')"
+            echo "PRE_UPDATE_PRODUCTION_SHA=$(git rev-parse origin/production)"
+            echo "PRE_UPDATE_PRODUCTION_TREE_SHA=$(git rev-parse 'origin/production^{tree}')"
+          } >> "$GITHUB_ENV"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -77,8 +79,10 @@ jobs:
           CURRENT_MAIN_SHA="$(git rev-parse origin/main)"
           if [ "$CURRENT_MAIN_SHA" != "$PRE_UPDATE_MAIN_SHA" ]; then
             echo "main moved while the workflow was running; skipping direct commit."
-            echo "MAIN_BRANCH_UPDATE_STATUS=skipped" >> "$GITHUB_ENV"
-            echo "MAIN_BRANCH_UPDATE_SKIP_REASON=main_moved" >> "$GITHUB_ENV"
+            {
+              echo "MAIN_BRANCH_UPDATE_STATUS=skipped"
+              echo "MAIN_BRANCH_UPDATE_SKIP_REASON=main_moved"
+            } >> "$GITHUB_ENV"
             exit 0
           fi
 
@@ -88,16 +92,20 @@ jobs:
 
           PUSHED_MAIN_SHA="$(git rev-parse HEAD)"
           if git push origin HEAD:main; then
-            echo "MAIN_BRANCH_UPDATE_STATUS=pushed" >> "$GITHUB_ENV"
-            echo "PUSHED_MAIN_SHA=${PUSHED_MAIN_SHA}" >> "$GITHUB_ENV"
+            {
+              echo "MAIN_BRANCH_UPDATE_STATUS=pushed"
+              echo "PUSHED_MAIN_SHA=${PUSHED_MAIN_SHA}"
+            } >> "$GITHUB_ENV"
             exit 0
           fi
 
           git fetch origin main
           if [ "$(git rev-parse origin/main)" != "$PRE_UPDATE_MAIN_SHA" ]; then
             echo "main moved before the push completed; skipping direct commit."
-            echo "MAIN_BRANCH_UPDATE_STATUS=skipped" >> "$GITHUB_ENV"
-            echo "MAIN_BRANCH_UPDATE_SKIP_REASON=main_moved" >> "$GITHUB_ENV"
+            {
+              echo "MAIN_BRANCH_UPDATE_STATUS=skipped"
+              echo "MAIN_BRANCH_UPDATE_SKIP_REASON=main_moved"
+            } >> "$GITHUB_ENV"
             exit 0
           fi
 
@@ -109,8 +117,10 @@ jobs:
         run: |
           if [ "$PRE_UPDATE_MAIN_TREE_SHA" != "$PRE_UPDATE_PRODUCTION_TREE_SHA" ]; then
             echo "production was not aligned with main at workflow start; skipping auto-merge."
-            echo "PRODUCTION_PROMOTION_STATUS=skipped" >> "$GITHUB_ENV"
-            echo "PRODUCTION_PROMOTION_SKIP_REASON=not_caught_up" >> "$GITHUB_ENV"
+            {
+              echo "PRODUCTION_PROMOTION_STATUS=skipped"
+              echo "PRODUCTION_PROMOTION_SKIP_REASON=not_caught_up"
+            } >> "$GITHUB_ENV"
             exit 0
           fi
 
@@ -119,16 +129,20 @@ jobs:
           CURRENT_MAIN_SHA="$(git rev-parse origin/main)"
           if [ "$CURRENT_MAIN_SHA" != "$PUSHED_MAIN_SHA" ]; then
             echo "main advanced after the stats commit; skipping production merge."
-            echo "PRODUCTION_PROMOTION_STATUS=skipped" >> "$GITHUB_ENV"
-            echo "PRODUCTION_PROMOTION_SKIP_REASON=main_moved" >> "$GITHUB_ENV"
+            {
+              echo "PRODUCTION_PROMOTION_STATUS=skipped"
+              echo "PRODUCTION_PROMOTION_SKIP_REASON=main_moved"
+            } >> "$GITHUB_ENV"
             exit 0
           fi
 
           CURRENT_PRODUCTION_SHA="$(git rev-parse origin/production)"
           if [ "$CURRENT_PRODUCTION_SHA" != "$PRE_UPDATE_PRODUCTION_SHA" ]; then
             echo "production advanced while the workflow was running; skipping auto-merge."
-            echo "PRODUCTION_PROMOTION_STATUS=skipped" >> "$GITHUB_ENV"
-            echo "PRODUCTION_PROMOTION_SKIP_REASON=production_moved" >> "$GITHUB_ENV"
+            {
+              echo "PRODUCTION_PROMOTION_STATUS=skipped"
+              echo "PRODUCTION_PROMOTION_SKIP_REASON=production_moved"
+            } >> "$GITHUB_ENV"
             exit 0
           fi
 
@@ -144,8 +158,10 @@ jobs:
           git fetch origin production
           if [ "$(git rev-parse origin/production)" != "$PRE_UPDATE_PRODUCTION_SHA" ]; then
             echo "production advanced before the merge push completed; skipping auto-merge."
-            echo "PRODUCTION_PROMOTION_STATUS=skipped" >> "$GITHUB_ENV"
-            echo "PRODUCTION_PROMOTION_SKIP_REASON=production_moved" >> "$GITHUB_ENV"
+            {
+              echo "PRODUCTION_PROMOTION_STATUS=skipped"
+              echo "PRODUCTION_PROMOTION_SKIP_REASON=production_moved"
+            } >> "$GITHUB_ENV"
             exit 0
           fi
 

--- a/.github/workflows/fetch_view_count.yaml
+++ b/.github/workflows/fetch_view_count.yaml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 concurrency:
   group: organization-stats-main
@@ -26,7 +25,18 @@ jobs:
 
       - name: Reset local main branch to origin/main
         if: github.ref_name == github.event.repository.default_branch
-        run: git checkout -B main origin/main
+        run: |
+          git fetch origin main production
+          git checkout -B main origin/main
+
+      - name: Capture branch baseline
+        if: github.ref_name == github.event.repository.default_branch
+        run: |
+          git fetch origin main production
+          echo "PRE_UPDATE_MAIN_SHA=$(git rev-parse origin/main)" >> "$GITHUB_ENV"
+          echo "PRE_UPDATE_MAIN_TREE_SHA=$(git rev-parse origin/main^{tree})" >> "$GITHUB_ENV"
+          echo "PRE_UPDATE_PRODUCTION_SHA=$(git rev-parse origin/production)" >> "$GITHUB_ENV"
+          echo "PRE_UPDATE_PRODUCTION_TREE_SHA=$(git rev-parse origin/production^{tree})" >> "$GITHUB_ENV"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -56,49 +66,90 @@ jobs:
             exit 1
           fi
 
-      - name: Commit and push stats branch
-        id: commit_and_push_stats_branch
+      - name: Commit and push to main
+        id: commit_and_push_to_main
         if: env.SHOULD_COMMIT == 'true' && github.ref_name == github.event.repository.default_branch
         run: |
           git config --global user.name "github-actions"
           git config --global user.email "github-actions@github.com"
-          git checkout -B chore/update-organization-stats
-          git add src/lib/organizationStats.json
-          git commit -m "chore(stats): update organization figures"
-          git push --force-with-lease origin chore/update-organization-stats
+          git fetch origin main production
 
-      - name: Create or update main PR
-        id: create_or_update_main_pr
-        if: env.SHOULD_COMMIT == 'true' && github.ref_name == github.event.repository.default_branch
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          BODY_FILE="$(mktemp)"
-          cat <<EOF > "$BODY_FILE"
-          ## Summary
-          - update the shared organization stats consumed by \`/about/concepts\` and \`/support-us\`
-          - refresh figures from the published attendance CSV and the YouTube channel statistics API
-
-          ## Updated figures
-          - total attendance: ${TOTAL_ATTENDANCE} (${DISPLAY_TOTAL_ATTENDANCE})
-          - YouTube subscribers: ${YOUTUBE_SUBSCRIBER_COUNT} (${DISPLAY_YOUTUBE_SUBSCRIBER_COUNT})
-          - YouTube total views: ${YOUTUBE_TOTAL_VIEW_COUNT} (${DISPLAY_YOUTUBE_TOTAL_VIEW_COUNT})
-          EOF
-
-          EXISTING_PR_NUMBER="$(gh pr list --base main --head chore/update-organization-stats --state open --json number --jq '.[0].number')"
-
-          if [ -n "$EXISTING_PR_NUMBER" ]; then
-            gh pr edit "$EXISTING_PR_NUMBER" \
-              --title "chore(stats): update organization figures" \
-              --body-file "$BODY_FILE"
+          CURRENT_MAIN_SHA="$(git rev-parse origin/main)"
+          if [ "$CURRENT_MAIN_SHA" != "$PRE_UPDATE_MAIN_SHA" ]; then
+            echo "main moved while the workflow was running; skipping direct commit."
+            echo "MAIN_BRANCH_UPDATE_STATUS=skipped" >> "$GITHUB_ENV"
+            echo "MAIN_BRANCH_UPDATE_SKIP_REASON=main_moved" >> "$GITHUB_ENV"
             exit 0
           fi
 
-          gh pr create \
-            --base main \
-            --head chore/update-organization-stats \
-            --title "chore(stats): update organization figures" \
-            --body-file "$BODY_FILE"
+          git checkout -B main origin/main
+          git add src/lib/organizationStats.json
+          git commit -m "chore(stats): update organization figures"
+
+          PUSHED_MAIN_SHA="$(git rev-parse HEAD)"
+          if git push origin HEAD:main; then
+            echo "MAIN_BRANCH_UPDATE_STATUS=pushed" >> "$GITHUB_ENV"
+            echo "PUSHED_MAIN_SHA=${PUSHED_MAIN_SHA}" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          git fetch origin main
+          if [ "$(git rev-parse origin/main)" != "$PRE_UPDATE_MAIN_SHA" ]; then
+            echo "main moved before the push completed; skipping direct commit."
+            echo "MAIN_BRANCH_UPDATE_STATUS=skipped" >> "$GITHUB_ENV"
+            echo "MAIN_BRANCH_UPDATE_SKIP_REASON=main_moved" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          exit 1
+
+      - name: Merge to production
+        id: merge_to_production
+        if: env.SHOULD_COMMIT == 'true' && github.ref_name == github.event.repository.default_branch && env.MAIN_BRANCH_UPDATE_STATUS == 'pushed'
+        run: |
+          if [ "$PRE_UPDATE_MAIN_TREE_SHA" != "$PRE_UPDATE_PRODUCTION_TREE_SHA" ]; then
+            echo "production was not aligned with main at workflow start; skipping auto-merge."
+            echo "PRODUCTION_PROMOTION_STATUS=skipped" >> "$GITHUB_ENV"
+            echo "PRODUCTION_PROMOTION_SKIP_REASON=not_caught_up" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          git fetch origin main production
+
+          CURRENT_MAIN_SHA="$(git rev-parse origin/main)"
+          if [ "$CURRENT_MAIN_SHA" != "$PUSHED_MAIN_SHA" ]; then
+            echo "main advanced after the stats commit; skipping production merge."
+            echo "PRODUCTION_PROMOTION_STATUS=skipped" >> "$GITHUB_ENV"
+            echo "PRODUCTION_PROMOTION_SKIP_REASON=main_moved" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          CURRENT_PRODUCTION_SHA="$(git rev-parse origin/production)"
+          if [ "$CURRENT_PRODUCTION_SHA" != "$PRE_UPDATE_PRODUCTION_SHA" ]; then
+            echo "production advanced while the workflow was running; skipping auto-merge."
+            echo "PRODUCTION_PROMOTION_STATUS=skipped" >> "$GITHUB_ENV"
+            echo "PRODUCTION_PROMOTION_SKIP_REASON=production_moved" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          git checkout -B production origin/production
+          RELEASE_DATE="$(TZ=Asia/Tokyo date '+%Y/%m/%d')"
+          git merge --no-ff origin/main -m "production release ${RELEASE_DATE}"
+
+          if git push origin HEAD:production; then
+            echo "PRODUCTION_PROMOTION_STATUS=merged" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          git fetch origin production
+          if [ "$(git rev-parse origin/production)" != "$PRE_UPDATE_PRODUCTION_SHA" ]; then
+            echo "production advanced before the merge push completed; skipping auto-merge."
+            echo "PRODUCTION_PROMOTION_STATUS=skipped" >> "$GITHUB_ENV"
+            echo "PRODUCTION_PROMOTION_SKIP_REASON=production_moved" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          exit 1
 
       - name: Post Slack summary
         if: always() && github.ref_name == github.event.repository.default_branch
@@ -111,6 +162,6 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           UPDATE_ORGANIZATION_STATS_OUTCOME: ${{ steps.update_organization_stats.outcome }}
           VALIDATE_CHANGED_FILES_OUTCOME: ${{ steps.validate_changed_files.outcome }}
-          COMMIT_AND_PUSH_STATS_BRANCH_OUTCOME: ${{ steps.commit_and_push_stats_branch.outcome }}
-          CREATE_OR_UPDATE_MAIN_PR_OUTCOME: ${{ steps.create_or_update_main_pr.outcome }}
+          COMMIT_AND_PUSH_TO_MAIN_OUTCOME: ${{ steps.commit_and_push_to_main.outcome }}
+          MERGE_TO_PRODUCTION_OUTCOME: ${{ steps.merge_to_production.outcome }}
         run: node .github/workflows/post_organization_stats_slack_summary.ts

--- a/.github/workflows/post_organization_stats_slack_summary.ts
+++ b/.github/workflows/post_organization_stats_slack_summary.ts
@@ -3,6 +3,10 @@ import {
 	formatOrganizationStatsSlackPayload,
 	type OrganizationStatsUpdateSummary
 } from '../../src/lib/organizationStatsUpdateSummary.ts';
+import {
+	type OrganizationStatsMainBranchUpdate,
+	type OrganizationStatsProductionPromotion
+} from '../../src/lib/organizationStatsWorkflowPromotion.ts';
 
 const SLACK_WEBHOOK_URL = process.env.SLACK_ORGANIZATION_STATS_WEBHOOK_URL;
 
@@ -29,11 +33,51 @@ const getFailedSteps = (): string[] =>
 	[
 		['Update organization stats', process.env.UPDATE_ORGANIZATION_STATS_OUTCOME],
 		['Validate changed files', process.env.VALIDATE_CHANGED_FILES_OUTCOME],
-		['Commit and push stats branch', process.env.COMMIT_AND_PUSH_STATS_BRANCH_OUTCOME],
-		['Create or update main PR', process.env.CREATE_OR_UPDATE_MAIN_PR_OUTCOME]
+		['Commit and push to main', process.env.COMMIT_AND_PUSH_TO_MAIN_OUTCOME],
+		['Merge to production', process.env.MERGE_TO_PRODUCTION_OUTCOME]
 	]
 		.filter(([, outcome]) => outcome === 'failure')
 		.map(([name]) => name);
+
+const parseMainBranchUpdate = (): OrganizationStatsMainBranchUpdate => {
+	if (process.env.MAIN_BRANCH_UPDATE_STATUS === 'pushed') {
+		return {
+			status: 'pushed'
+		};
+	}
+
+	if (process.env.MAIN_BRANCH_UPDATE_STATUS === 'skipped') {
+		return {
+			status: 'skipped',
+			reason: 'main_moved'
+		};
+	}
+
+	return {
+		status: 'not_attempted'
+	};
+};
+
+const parseProductionPromotion = (): OrganizationStatsProductionPromotion => {
+	if (process.env.PRODUCTION_PROMOTION_STATUS === 'merged') {
+		return {
+			status: 'merged'
+		};
+	}
+
+	if (process.env.PRODUCTION_PROMOTION_STATUS === 'skipped') {
+		const reason = process.env.PRODUCTION_PROMOTION_SKIP_REASON;
+
+		return {
+			status: 'skipped',
+			reason: reason === 'main_moved' || reason === 'production_moved' ? reason : 'not_caught_up'
+		};
+	}
+
+	return {
+		status: 'not_attempted'
+	};
+};
 
 const getRunUrl = (): string | undefined => {
 	const serverUrl = process.env.GITHUB_SERVER_URL;
@@ -56,6 +100,8 @@ const postSlackSummary = async (): Promise<void> => {
 	const payload = formatOrganizationStatsSlackPayload(summary, {
 		failedSteps: getFailedSteps(),
 		runUrl: getRunUrl(),
+		mainBranchUpdate: parseMainBranchUpdate(),
+		productionPromotion: parseProductionPromotion(),
 		workflowStatus: process.env.WORKFLOW_JOB_STATUS
 	});
 	const response = await fetch(SLACK_WEBHOOK_URL, {

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ vite.config.ts.timestamp-*
 .dev.vars
 /coverage
 .codex
+.serena

--- a/src/lib/__tests__/organizationStatsUpdateSummary.test.ts
+++ b/src/lib/__tests__/organizationStatsUpdateSummary.test.ts
@@ -223,6 +223,69 @@ describe('organization stats update summary', () => {
 		expect(verificationOnlyColor).toBe('good');
 	});
 
+	it('formats successful direct main and production updates', () => {
+		const text = formatOrganizationStatsSlackSummary(
+			summarizeOrganizationStatsUpdate(
+				{
+					totalAttendance: 7867,
+					youtubeSubscriberCount: 15000,
+					youtubeTotalViewCount: 6607890,
+					youtubeSubscriberCountVerified: true
+				},
+				{
+					totalAttendance: 8001,
+					youtubeSubscriberCount: 16050,
+					youtubeTotalViewCount: 6704321
+				}
+			),
+			{
+				generatedAt,
+				mainBranchUpdate: {
+					status: 'pushed'
+				},
+				productionPromotion: {
+					status: 'merged'
+				}
+			}
+		);
+
+		expect(text).toContain('- main: 直接コミット完了');
+		expect(text).toContain('- production: main の最新コミットを自動マージ');
+	});
+
+	it('formats production skip reasons when the stats commit stays only on main', () => {
+		const text = formatOrganizationStatsSlackSummary(
+			summarizeOrganizationStatsUpdate(
+				{
+					totalAttendance: 7867,
+					youtubeSubscriberCount: 15000,
+					youtubeTotalViewCount: 6607890,
+					youtubeSubscriberCountVerified: true
+				},
+				{
+					totalAttendance: 8001,
+					youtubeSubscriberCount: 16050,
+					youtubeTotalViewCount: 6704321
+				}
+			),
+			{
+				generatedAt,
+				mainBranchUpdate: {
+					status: 'pushed'
+				},
+				productionPromotion: {
+					status: 'skipped',
+					reason: 'not_caught_up'
+				}
+			}
+		);
+
+		expect(text).toContain('- main: 直接コミット完了');
+		expect(text).toContain(
+			'- production: スキップ（実行開始時点で production が main と同一内容ではありません）'
+		);
+	});
+
 	it('formats workflow failures as errors while preserving fetched values', () => {
 		const payload = formatOrganizationStatsSlackPayload(
 			summarizeOrganizationStatsUpdate(
@@ -241,13 +304,24 @@ describe('organization stats update summary', () => {
 			{
 				generatedAt,
 				workflowStatus: 'failure',
-				failedSteps: ['Create or update main PR']
+				failedSteps: ['Merge to production'],
+				mainBranchUpdate: {
+					status: 'pushed'
+				},
+				productionPromotion: {
+					status: 'skipped',
+					reason: 'production_moved'
+				}
 			}
 		);
 
 		expect(payload.text).toContain('サマリー: 🔴 エラー');
-		expect(payload.text).toContain('Create or update main PR');
+		expect(payload.text).toContain('Merge to production');
 		expect(payload.text).toContain('- 🟢 累計来場者数 7,868名 (+1)');
+		expect(payload.text).toContain('- main: 直接コミット完了');
+		expect(payload.text).toContain(
+			'- production: スキップ（実行中に production が更新されました）'
+		);
 	});
 
 	it('returns danger for non-success workflow states and direct errors', () => {

--- a/src/lib/__tests__/organizationStatsWorkflowPromotion.test.ts
+++ b/src/lib/__tests__/organizationStatsWorkflowPromotion.test.ts
@@ -1,0 +1,192 @@
+import { execFile } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { promisify } from 'node:util';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+	getOrganizationStatsProductionPromotionGate,
+	hasMatchingBranchContent
+} from '../organizationStatsWorkflowPromotion';
+
+const execFileAsync = promisify(execFile);
+const temporaryDirectories: string[] = [];
+
+const runGit = async (cwd: string, args: string[]): Promise<string> => {
+	const { stdout } = await execFileAsync('git', args, {
+		cwd,
+		env: {
+			...process.env,
+			GIT_AUTHOR_NAME: 'Test User',
+			GIT_AUTHOR_EMAIL: 'test@example.com',
+			GIT_COMMITTER_NAME: 'Test User',
+			GIT_COMMITTER_EMAIL: 'test@example.com'
+		}
+	});
+
+	return stdout.trim();
+};
+
+const writeTrackedFile = async (cwd: string, content: string): Promise<void> => {
+	await writeFile(join(cwd, 'stats.txt'), `${content}\n`, 'utf-8');
+	await runGit(cwd, ['add', 'stats.txt']);
+};
+
+const commitFileOnBranch = async (
+	cwd: string,
+	branch: string,
+	content: string,
+	message: string
+) => {
+	await runGit(cwd, ['checkout', branch]);
+	await writeTrackedFile(cwd, content);
+	await runGit(cwd, ['commit', '-m', message]);
+};
+
+const commitEmptyOnBranch = async (cwd: string, branch: string, message: string) => {
+	await runGit(cwd, ['checkout', branch]);
+	await runGit(cwd, ['commit', '--allow-empty', '-m', message]);
+};
+
+const getRevision = async (cwd: string, revision: string): Promise<string> =>
+	runGit(cwd, ['rev-parse', revision]);
+
+const createRepository = async (): Promise<string> => {
+	const cwd = await mkdtemp(join(tmpdir(), 'organization-stats-promotion-'));
+	temporaryDirectories.push(cwd);
+	await runGit(cwd, ['init', '--initial-branch=main']);
+	await runGit(cwd, ['config', 'user.name', 'Test User']);
+	await runGit(cwd, ['config', 'user.email', 'test@example.com']);
+	await writeTrackedFile(cwd, 'baseline');
+	await runGit(cwd, ['commit', '-m', 'initial commit']);
+	await runGit(cwd, ['branch', 'production']);
+
+	return cwd;
+};
+
+afterEach(async () => {
+	await Promise.all(
+		temporaryDirectories
+			.splice(0)
+			.map((directory) => rm(directory, { force: true, recursive: true }))
+	);
+});
+
+describe('organization stats workflow promotion', () => {
+	it('treats matching branch trees as releasable even when commit history differs', async () => {
+		const cwd = await createRepository();
+		await commitEmptyOnBranch(cwd, 'production', 'production release marker');
+
+		const mainTreeSha = await getRevision(cwd, 'main^{tree}');
+		const productionTreeSha = await getRevision(cwd, 'production^{tree}');
+		const expectedMainSha = await getRevision(cwd, 'main');
+		const expectedProductionSha = await getRevision(cwd, 'production');
+
+		expect(hasMatchingBranchContent(mainTreeSha, productionTreeSha)).toBe(true);
+		expect(
+			getOrganizationStatsProductionPromotionGate({
+				currentMainSha: expectedMainSha,
+				currentProductionSha: expectedProductionSha,
+				expectedMainSha,
+				expectedProductionSha,
+				mainBranchUpdate: {
+					status: 'pushed'
+				},
+				preUpdateMainTreeSha: mainTreeSha,
+				preUpdateProductionTreeSha: productionTreeSha
+			})
+		).toEqual({
+			status: 'ready'
+		});
+	});
+
+	it('skips production promotion when production content is behind main at workflow start', async () => {
+		const cwd = await createRepository();
+		await commitFileOnBranch(cwd, 'main', 'main changed', 'main update');
+
+		const mainTreeSha = await getRevision(cwd, 'main^{tree}');
+		const productionTreeSha = await getRevision(cwd, 'production^{tree}');
+
+		expect(
+			getOrganizationStatsProductionPromotionGate({
+				currentMainSha: await getRevision(cwd, 'main'),
+				currentProductionSha: await getRevision(cwd, 'production'),
+				expectedMainSha: await getRevision(cwd, 'main'),
+				expectedProductionSha: await getRevision(cwd, 'production'),
+				mainBranchUpdate: {
+					status: 'pushed'
+				},
+				preUpdateMainTreeSha: mainTreeSha,
+				preUpdateProductionTreeSha: productionTreeSha
+			})
+		).toEqual({
+			status: 'skipped',
+			reason: 'not_caught_up'
+		});
+	});
+
+	it('skips production promotion when main advances after the stats commit', async () => {
+		const cwd = await createRepository();
+		await commitEmptyOnBranch(cwd, 'production', 'production release marker');
+
+		const preUpdateMainTreeSha = await getRevision(cwd, 'main^{tree}');
+		const preUpdateProductionTreeSha = await getRevision(cwd, 'production^{tree}');
+		const expectedMainSha = await getRevision(cwd, 'main');
+		const expectedProductionSha = await getRevision(cwd, 'production');
+
+		await commitFileOnBranch(cwd, 'main', 'main advanced', 'unexpected main advance');
+
+		expect(
+			getOrganizationStatsProductionPromotionGate({
+				currentMainSha: await getRevision(cwd, 'main'),
+				currentProductionSha: await getRevision(cwd, 'production'),
+				expectedMainSha,
+				expectedProductionSha,
+				mainBranchUpdate: {
+					status: 'pushed'
+				},
+				preUpdateMainTreeSha,
+				preUpdateProductionTreeSha
+			})
+		).toEqual({
+			status: 'skipped',
+			reason: 'main_moved'
+		});
+	});
+
+	it('skips production promotion when production advances after the baseline check', async () => {
+		const cwd = await createRepository();
+		await commitEmptyOnBranch(cwd, 'production', 'production release marker');
+
+		const preUpdateMainTreeSha = await getRevision(cwd, 'main^{tree}');
+		const preUpdateProductionTreeSha = await getRevision(cwd, 'production^{tree}');
+		const expectedMainSha = await getRevision(cwd, 'main');
+		const expectedProductionSha = await getRevision(cwd, 'production');
+
+		await commitFileOnBranch(
+			cwd,
+			'production',
+			'production advanced',
+			'unexpected production advance'
+		);
+
+		expect(
+			getOrganizationStatsProductionPromotionGate({
+				currentMainSha: await getRevision(cwd, 'main'),
+				currentProductionSha: await getRevision(cwd, 'production'),
+				expectedMainSha,
+				expectedProductionSha,
+				mainBranchUpdate: {
+					status: 'pushed'
+				},
+				preUpdateMainTreeSha,
+				preUpdateProductionTreeSha
+			})
+		).toEqual({
+			status: 'skipped',
+			reason: 'production_moved'
+		});
+	});
+});

--- a/src/lib/__tests__/organizationStatsWorkflowPromotion.test.ts
+++ b/src/lib/__tests__/organizationStatsWorkflowPromotion.test.ts
@@ -15,7 +15,7 @@ const execFileAsync = promisify(execFile);
 const temporaryDirectories: string[] = [];
 
 const runGit = async (cwd: string, args: string[]): Promise<string> => {
-	const { stdout } = await execFileAsync('git', args, {
+	const { stdout } = await execFileAsync('git', ['-c', 'commit.gpgsign=false', ...args], {
 		cwd,
 		env: {
 			...process.env,

--- a/src/lib/organizationStatsUpdateSummary.ts
+++ b/src/lib/organizationStatsUpdateSummary.ts
@@ -7,6 +7,12 @@ import {
 	type OrganizationStats,
 	type PersistedOrganizationStats
 } from './organizationStats.ts';
+import {
+	type OrganizationStatsMainBranchUpdate,
+	type OrganizationStatsMainBranchUpdateSkipReason,
+	type OrganizationStatsProductionPromotion,
+	type OrganizationStatsProductionPromotionSkipReason
+} from './organizationStatsWorkflowPromotion.ts';
 
 export type OrganizationStatsFieldKey = keyof OrganizationStats;
 
@@ -39,6 +45,8 @@ export type OrganizationStatsUpdateSummary =
 export type OrganizationStatsSlackSummaryOptions = {
 	failedSteps?: string[];
 	generatedAt?: Date;
+	mainBranchUpdate?: OrganizationStatsMainBranchUpdate;
+	productionPromotion?: OrganizationStatsProductionPromotion;
 	runUrl?: string;
 	summaryDate?: string;
 	workflowStatus?: string;
@@ -205,6 +213,58 @@ const formatWorkflowStatusDetail = (
 	return 'GitHub Actions の実行に失敗しました。';
 };
 
+const formatMainBranchUpdateSkipReason = (
+	reason: OrganizationStatsMainBranchUpdateSkipReason
+): string => {
+	if (reason === 'main_moved') {
+		return '実行中に main が更新されました';
+	}
+
+	return reason;
+};
+
+const formatProductionPromotionSkipReason = (
+	reason: OrganizationStatsProductionPromotionSkipReason
+): string => {
+	if (reason === 'not_caught_up') {
+		return '実行開始時点で production が main と同一内容ではありません';
+	}
+
+	if (reason === 'main_moved') {
+		return 'production 反映前に main が更新されました';
+	}
+
+	return '実行中に production が更新されました';
+};
+
+const formatMainBranchUpdate = (
+	mainBranchUpdate: OrganizationStatsMainBranchUpdate
+): string | undefined => {
+	if (mainBranchUpdate.status === 'not_attempted') {
+		return undefined;
+	}
+
+	if (mainBranchUpdate.status === 'pushed') {
+		return 'main: 直接コミット完了';
+	}
+
+	return `main: スキップ（${formatMainBranchUpdateSkipReason(mainBranchUpdate.reason)}）`;
+};
+
+const formatProductionPromotion = (
+	productionPromotion: OrganizationStatsProductionPromotion
+): string | undefined => {
+	if (productionPromotion.status === 'not_attempted') {
+		return undefined;
+	}
+
+	if (productionPromotion.status === 'merged') {
+		return 'production: main の最新コミットを自動マージ';
+	}
+
+	return `production: スキップ（${formatProductionPromotionSkipReason(productionPromotion.reason)}）`;
+};
+
 const getSlackSummaryLabel = (
 	summary: OrganizationStatsUpdateSummary,
 	options: Pick<OrganizationStatsSlackSummaryOptions, 'workflowStatus'>
@@ -231,6 +291,10 @@ const createSlackSummaryParts = (
 	const summaryLines = [
 		`*サマリー: ${slackSummaryIcons[slackColor]} ${getSlackSummaryLabel(summary, options)}*`
 	];
+	const branchStatusLines = [
+		options.mainBranchUpdate ? formatMainBranchUpdate(options.mainBranchUpdate) : undefined,
+		options.productionPromotion ? formatProductionPromotion(options.productionPromotion) : undefined
+	].filter((line): line is string => line !== undefined);
 	const metricRows =
 		summary.status === 'error'
 			? []
@@ -246,6 +310,8 @@ const createSlackSummaryParts = (
 			`詳細: ${escapeSlackText(formatWorkflowStatusDetail(options.workflowStatus, failedSteps))}`
 		);
 	}
+
+	summaryLines.push(...branchStatusLines.map((line) => `- ${line}`));
 
 	return {
 		title,

--- a/src/lib/organizationStatsWorkflowPromotion.ts
+++ b/src/lib/organizationStatsWorkflowPromotion.ts
@@ -1,0 +1,97 @@
+export type OrganizationStatsMainBranchUpdateSkipReason = 'main_moved';
+
+export type OrganizationStatsProductionPromotionSkipReason =
+	| 'not_caught_up'
+	| 'main_moved'
+	| 'production_moved';
+
+export type OrganizationStatsMainBranchUpdate =
+	| {
+			status: 'not_attempted';
+	  }
+	| {
+			status: 'pushed';
+	  }
+	| {
+			status: 'skipped';
+			reason: OrganizationStatsMainBranchUpdateSkipReason;
+	  };
+
+export type OrganizationStatsProductionPromotion =
+	| {
+			status: 'not_attempted';
+	  }
+	| {
+			status: 'merged';
+	  }
+	| {
+			status: 'skipped';
+			reason: OrganizationStatsProductionPromotionSkipReason;
+	  };
+
+export const hasMatchingBranchContent = (mainTreeSha: string, productionTreeSha: string): boolean =>
+	mainTreeSha === productionTreeSha;
+
+export const getOrganizationStatsProductionPromotionGate = ({
+	currentMainSha,
+	currentProductionSha,
+	expectedMainSha,
+	expectedProductionSha,
+	mainBranchUpdate,
+	preUpdateMainTreeSha,
+	preUpdateProductionTreeSha
+}: {
+	currentMainSha: string;
+	currentProductionSha: string;
+	expectedMainSha: string;
+	expectedProductionSha: string;
+	mainBranchUpdate: OrganizationStatsMainBranchUpdate;
+	preUpdateMainTreeSha: string;
+	preUpdateProductionTreeSha: string;
+}):
+	| {
+			status: 'ready';
+	  }
+	| {
+			status: 'skipped';
+			reason: OrganizationStatsProductionPromotionSkipReason;
+	  } => {
+	if (mainBranchUpdate.status === 'not_attempted') {
+		return {
+			status: 'skipped',
+			reason: 'main_moved'
+		};
+	}
+
+	if (mainBranchUpdate.status === 'skipped') {
+		return {
+			status: 'skipped',
+			reason: mainBranchUpdate.reason
+		};
+	}
+
+	if (!hasMatchingBranchContent(preUpdateMainTreeSha, preUpdateProductionTreeSha)) {
+		return {
+			status: 'skipped',
+			reason: 'not_caught_up'
+		};
+	}
+
+	if (currentMainSha !== expectedMainSha) {
+		return {
+			status: 'skipped',
+			reason: 'main_moved'
+		};
+	}
+
+	if (currentProductionSha !== expectedProductionSha) {
+		return {
+			status: 'skipped',
+			reason: 'production_moved'
+		};
+	}
+
+	return {
+		status: 'ready'
+	};
+};


### PR DESCRIPTION
## Summary
- change the organization stats workflow to commit directly to `main` instead of opening an intermediate PR branch
- merge that new stats commit into `production` in the same workflow only when `production` matched the pre-run `main` content and neither branch moved during the run
- extend the Slack summary/reporting path with explicit `main` push and `production` promotion states, and add tests for the promotion guard logic
- keep the existing `main` -> `production` PR workflow for normal changes, but ignore stats-only pushes so this automation does not create a duplicate release PR
- ignore `.serena` in the repo-level `.gitignore` so local Serena workspace files do not keep appearing as untracked noise

## Why
The existing flow stopped at a PR into `main`, which blocked the fully automated stats update path. At the same time, auto-promoting to `production` needs a guard so the workflow does not accidentally ship unrelated unreleased changes when `main` and `production` have diverged.

The follow-up `.serena` ignore change keeps local agent workspace artifacts out of normal repo status and reduces accidental commit noise, matching the existing `.codex` ignore pattern.

## Impact
Scheduled organization stats updates can now land on `main` automatically and promote to `production` only when the release boundary is still clean. When the guard does not pass, the run keeps the commit on `main`, skips `production`, and reports the reason clearly in Slack/logs.

Local Serena files are now ignored by default for this repo.

## Validation
- `npm run check`
- `npm run lint`
- `npm test`

## Notes
- `gh auth status` is currently invalid in this checkout, so the PR was created through the GitHub connector instead of the GitHub CLI.
- The repo still has pre-existing `svelte-check` warnings in `src/routes/+page.svelte` and `src/routes/concerts/archives/Concert.svelte`; they did not block the commit hook or this change.