### PR TITLE
[codex] Update patronage return tiers

### DIFF
--- a/src/routes/support-us/+page.svelte
+++ b/src/routes/support-us/+page.svelte
@@ -132,22 +132,22 @@
 						<td>-</td>
 					</tr>
 					<tr>
-						<td>3,000〜4,999</td>
-						<td>2名様</td>
+						<td>3,000〜5,999</td>
+						<td>1名様</td>
 						<td>1年間</td>
 						<td>-</td>
 						<td>-</td>
 					</tr>
 					<tr>
-						<td>5,000〜6,999</td>
-						<td>4名様</td>
+						<td>6,000〜6,999</td>
+						<td>3名様</td>
 						<td>1年間</td>
 						<td>-</td>
 						<td>-</td>
 					</tr>
 					<tr>
 						<td>7,000〜9,999</td>
-						<td>6名様</td>
+						<td>4名様</td>
 						<td>1年間</td>
 						<td>-</td>
 						<td>-</td>
@@ -196,22 +196,22 @@
 						<td colspan="2">-</td>
 					</tr>
 					<tr>
-						<td>3,000〜4,999</td>
-						<td>2名様</td>
+						<td>3,000〜5,999</td>
+						<td>1名様</td>
 						<td>1年間</td>
 						<td>-</td>
 						<td colspan="2">-</td>
 					</tr>
 					<tr>
-						<td>5,000〜6,999</td>
-						<td>4名様</td>
+						<td>6,000〜6,999</td>
+						<td>3名様</td>
 						<td>1年間</td>
 						<td>-</td>
 						<td colspan="2">-</td>
 					</tr>
 					<tr>
 						<td>7,000〜9,999</td>
-						<td>6名様</td>
+						<td>4名様</td>
 						<td>1年間</td>
 						<td>-</td>
 						<td colspan="2">-</td>


### PR DESCRIPTION
## Summary

Closes #235.

- `/support-us` の「ご返礼・特典（個人の皆様）」の寄付額区分とご招待人数を新制度へ更新
- `/support-us` の「ご返礼・特典（法人の皆様）」の寄付額区分とご招待人数を新制度へ更新
- 法人向けの協賛・特別協賛説明、脚注、フォーム導線、その他セクションは変更なし

## Changes

### 個人向け

- `3,000〜4,999 / 2名様` -> `3,000〜5,999 / 1名様`
- `5,000〜6,999 / 4名様` -> `6,000〜6,999 / 3名様`
- `7,000〜9,999 / 6名様` -> `7,000〜9,999 / 4名様`

### 法人向け

- `3,000〜4,999 / 2名様` -> `3,000〜5,999 / 1名様`
- `5,000〜6,999 / 4名様` -> `6,000〜6,999 / 3名様`
- `7,000〜9,999 / 6名様` -> `7,000〜9,999 / 4名様`

## Validation

- `npm run check` passed with existing Svelte warnings only
- `npm run lint` passed
- `npm run build` passed with existing Svelte warnings only
- `npm test` passed: 12 files / 81 tests
- precommit hook passed: check, prettier, eslint, vitest
- Playwright visual check on `http://127.0.0.1:4173/support-us` at desktop width and mobile width
  - Desktop: both tables render in place
  - Mobile: existing horizontal scroll containers preserve table readability/accessibility
