### PR TITLE
[codex] Split organization stats Slack summary

### DIFF
--- a/src/lib/__tests__/organizationStats.test.ts
+++ b/src/lib/__tests__/organizationStats.test.ts
@@ -7,6 +7,7 @@ import {
 	formatYouTubeSubscriberCount,
 	formatYouTubeTotalViewCount,
 	hasOrganizationStatsDisplayChange,
+	hasOrganizationStatsValueChange,
 	shouldPersistOrganizationStats
 } from '../organizationStats';
 
@@ -59,7 +60,24 @@ describe('formatters', () => {
 		).toBe(true);
 	});
 
-	it('persists the first verified subscriber count even when the display bucket is unchanged', () => {
+	it('detects raw value changes independently of display bucket changes', () => {
+		expect(
+			hasOrganizationStatsValueChange(
+				{
+					totalAttendance: 7867,
+					youtubeSubscriberCount: 15000,
+					youtubeTotalViewCount: 6607890
+				},
+				{
+					totalAttendance: 7999,
+					youtubeSubscriberCount: 15999,
+					youtubeTotalViewCount: 6699999
+				}
+			)
+		).toBe(true);
+	});
+
+	it('persists the first verified subscriber count and raw value changes', () => {
 		expect(
 			shouldPersistOrganizationStats(
 				{
@@ -90,7 +108,7 @@ describe('formatters', () => {
 					youtubeTotalViewCount: 6699999
 				}
 			)
-		).toBe(false);
+		).toBe(true);
 	});
 });
 

--- a/src/lib/__tests__/organizationStatsUpdateSummary.test.ts
+++ b/src/lib/__tests__/organizationStatsUpdateSummary.test.ts
@@ -11,7 +11,7 @@ import {
 describe('organization stats update summary', () => {
 	const generatedAt = new Date('2026-04-10T02:50:24.893Z');
 
-	it('marks raw numeric changes as updated even when display buckets stay the same', () => {
+	it('keeps the summary unchanged when only raw values change within display buckets', () => {
 		const summary = summarizeOrganizationStatsUpdate(
 			{
 				totalAttendance: 7867,
@@ -27,9 +27,9 @@ describe('organization stats update summary', () => {
 		);
 
 		expect(summary).toMatchObject({
-			status: 'updated',
-			shouldPersist: false,
-			persistReasons: []
+			status: 'no_change',
+			shouldPersist: true,
+			persistReasons: ['stats_change']
 		});
 		expect(
 			summary.status === 'error' ? [] : summary.fields.filter((field) => field.changed)
@@ -79,20 +79,25 @@ describe('organization stats update summary', () => {
 			}
 		);
 
-		expect(payload.text).toContain('団体情報統計 更新サマリー | 2026-04-09 JST');
+		expect(payload.text).toContain('団体情報統計 更新サマリー | 2026-04-10 JST');
 		expect(payload.text).toContain('生成: 2026-04-10T02:50:24.893Z');
 		expect(payload.text).toContain('サマリー: 🟡 3件更新');
-		expect(payload.text).toContain('- 🟡 YT総再生回数 6,704,321回 (+96,431)');
-		expect(payload.text).toContain('- 🟡 YT登録者数 16,050人 (+1,050)');
-		expect(payload.text).toContain('- 🟡 累計来場者数 8,001名 (+134)');
-		expect(payload.text).toContain('公開用JSON: 更新対象あり（表示値差分あり）');
+		expect(payload.text).toContain('統計データ（前回取得値との差分）');
+		expect(payload.text).toContain('- YT総再生回数 6,704,321回 (+96,431)');
+		expect(payload.text).toContain('- YT登録者数 16,050人 (+1,050)');
+		expect(payload.text).toContain('- 累計来場者数 8,001名 (+134)');
+		expect(payload.text).toContain('表示データ（HP表示値）');
+		expect(payload.text).toContain('- 🟡 YT総再生回数 660万回 → 670万回');
+		expect(payload.text).toContain('- 🟡 YT登録者数 1.5万人 → 1.6万人');
+		expect(payload.text).toContain('- 🟡 累計来場者数 7,000名 → 8,000名');
+		expect(payload.text).toContain('保存データ: 更新対象あり（統計値差分あり）');
 		expect(payload.text).toContain('<https://example.com/runs/1|実行ログ>');
 		expect(payload.blocks.slice(0, 4)).toMatchObject([
 			{
 				type: 'section',
 				text: {
 					type: 'mrkdwn',
-					text: '*団体情報統計 更新サマリー | 2026-04-09 JST*'
+					text: '*団体情報統計 更新サマリー | 2026-04-10 JST*'
 				}
 			},
 			{
@@ -138,13 +143,16 @@ describe('organization stats update summary', () => {
 		);
 
 		expect(text).toContain('サマリー: 🟢 更新なし');
-		expect(text).toContain('- 🟢 YT総再生回数 6,607,890回');
-		expect(text).toContain('- 🟢 YT登録者数 15,000人');
-		expect(text).toContain('- 🟢 累計来場者数 7,867名');
-		expect(text).toContain('公開用JSON: 更新対象あり（登録者数検証フラグを確定）');
+		expect(text).toContain('- YT総再生回数 6,607,890回 (0)');
+		expect(text).toContain('- YT登録者数 15,000人 (0)');
+		expect(text).toContain('- 累計来場者数 7,867名 (0)');
+		expect(text).toContain('- 🟢 YT総再生回数 660万回（変更なし）');
+		expect(text).toContain('- 🟢 YT登録者数 1.5万人（変更なし）');
+		expect(text).toContain('- 🟢 累計来場者数 7,000名（変更なし）');
+		expect(text).toContain('保存データ: 更新対象あり（登録者数検証フラグを確定）');
 	});
 
-	it('keeps summary and metric markers green when raw values changed but JSON is not persisted', () => {
+	it('keeps summary green when raw values change without display changes', () => {
 		const payload = formatOrganizationStatsSlackPayload(
 			summarizeOrganizationStatsUpdate(
 				{
@@ -164,14 +172,17 @@ describe('organization stats update summary', () => {
 			}
 		);
 
-		expect(payload.text).toContain('サマリー: 🟢 3件更新');
-		expect(payload.text).toContain('- 🟢 YT総再生回数 6,699,999回 (+92,109)');
-		expect(payload.text).toContain('- 🟢 YT登録者数 15,999人 (+999)');
-		expect(payload.text).toContain('- 🟢 累計来場者数 7,999名 (+132)');
-		expect(payload.text).toContain('公開用JSON: 変更なし');
+		expect(payload.text).toContain('サマリー: 🟢 更新なし');
+		expect(payload.text).toContain('- YT総再生回数 6,699,999回 (+92,109)');
+		expect(payload.text).toContain('- YT登録者数 15,999人 (+999)');
+		expect(payload.text).toContain('- 累計来場者数 7,999名 (+132)');
+		expect(payload.text).toContain('- 🟢 YT総再生回数 660万回（変更なし）');
+		expect(payload.text).toContain('- 🟢 YT登録者数 1.5万人（変更なし）');
+		expect(payload.text).toContain('- 🟢 累計来場者数 7,000名（変更なし）');
+		expect(payload.text).toContain('保存データ: 更新対象あり（統計値差分あり）');
 	});
 
-	it('returns warning only when changed values require a persisted JSON update', () => {
+	it('returns warning only when display values change', () => {
 		const warningColor = getOrganizationStatsSlackColor(
 			summarizeOrganizationStatsUpdate(
 				{
@@ -317,7 +328,8 @@ describe('organization stats update summary', () => {
 
 		expect(payload.text).toContain('サマリー: 🔴 エラー');
 		expect(payload.text).toContain('Merge to production');
-		expect(payload.text).toContain('- 🟢 累計来場者数 7,868名 (+1)');
+		expect(payload.text).toContain('- 累計来場者数 7,868名 (+1)');
+		expect(payload.text).toContain('- 🟢 累計来場者数 7,000名（変更なし）');
 		expect(payload.text).toContain('- main: 直接コミット完了');
 		expect(payload.text).toContain(
 			'- production: スキップ（実行中に production が更新されました）'

--- a/src/lib/organizationStats.ts
+++ b/src/lib/organizationStats.ts
@@ -66,12 +66,20 @@ export const hasOrganizationStatsDisplayChange = (
 	);
 };
 
+export const hasOrganizationStatsValueChange = (
+	currentStats: OrganizationStats,
+	nextStats: OrganizationStats
+): boolean =>
+	currentStats.totalAttendance !== nextStats.totalAttendance ||
+	currentStats.youtubeSubscriberCount !== nextStats.youtubeSubscriberCount ||
+	currentStats.youtubeTotalViewCount !== nextStats.youtubeTotalViewCount;
+
 export const shouldPersistOrganizationStats = (
 	currentStats: PersistedOrganizationStats,
 	nextStats: OrganizationStats
 ): boolean =>
 	!currentStats.youtubeSubscriberCountVerified ||
-	hasOrganizationStatsDisplayChange(currentStats, nextStats);
+	hasOrganizationStatsValueChange(currentStats, nextStats);
 
 export const parseCsvText = (csvText: string): string[][] => {
 	const rows: string[][] = [];

--- a/src/lib/organizationStatsUpdateSummary.ts
+++ b/src/lib/organizationStatsUpdateSummary.ts
@@ -2,7 +2,6 @@ import {
 	formatAttendanceCount,
 	formatYouTubeSubscriberCount,
 	formatYouTubeTotalViewCount,
-	hasOrganizationStatsDisplayChange,
 	shouldPersistOrganizationStats,
 	type OrganizationStats,
 	type PersistedOrganizationStats
@@ -16,7 +15,7 @@ import {
 
 export type OrganizationStatsFieldKey = keyof OrganizationStats;
 
-export type OrganizationStatsPersistReason = 'display_change' | 'subscriber_verification';
+export type OrganizationStatsPersistReason = 'stats_change' | 'subscriber_verification';
 
 export type OrganizationStatsFieldSummary = {
 	key: OrganizationStatsFieldKey;
@@ -117,7 +116,6 @@ const slackSummaryIcons = {
 	danger: '🔴'
 } satisfies Record<OrganizationStatsSlackColor, string>;
 
-const DAY_IN_MILLISECONDS = 24 * 60 * 60 * 1000;
 const JST_OFFSET_MILLISECONDS = 9 * 60 * 60 * 1000;
 
 const formatRawInteger = (value: number): string => value.toLocaleString('ja-JP');
@@ -132,25 +130,24 @@ const formatPersistDecision = (
 	summary: Extract<OrganizationStatsUpdateSummary, { status: 'updated' | 'no_change' }>
 ): string => {
 	if (!summary.shouldPersist) {
-		return '公開用JSON: 変更なし';
+		return '保存データ: 変更なし';
 	}
 
 	const reasons = summary.persistReasons.map((reason) => {
-		if (reason === 'display_change') {
-			return '表示値差分あり';
+		if (reason === 'stats_change') {
+			return '統計値差分あり';
 		}
 
 		return '登録者数検証フラグを確定';
 	});
 
-	return `公開用JSON: 更新対象あり（${reasons.join(' / ')}）`;
+	return `保存データ: 更新対象あり（${reasons.join(' / ')}）`;
 };
 
 const formatJstDate = (date: Date): string =>
 	new Date(date.getTime() + JST_OFFSET_MILLISECONDS).toISOString().slice(0, 10);
 
-const getDefaultSummaryDate = (generatedAt: Date): string =>
-	formatJstDate(new Date(generatedAt.getTime() - DAY_IN_MILLISECONDS));
+const getDefaultSummaryDate = (generatedAt: Date): string => formatJstDate(generatedAt);
 
 const escapeSlackText = (value: string): string =>
 	value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
@@ -183,14 +180,16 @@ const getOrderedSlackFields = (
 		return field;
 	});
 
-const formatSlackMetricField = (
-	field: OrganizationStatsFieldSummary,
-	highlightChangedValues: boolean
-): string => {
-	const delta = field.changed ? ` (${formatSignedInteger(field.delta)})` : '';
-	const statusIcon = highlightChangedValues && field.changed ? '🟡' : '🟢';
+const formatSlackStatisticField = (field: OrganizationStatsFieldSummary): string =>
+	`- ${slackMetricLabels[field.key]} ${formatRawInteger(field.nextValue)}${slackMetricUnits[field.key]} (${formatSignedInteger(field.delta)})`;
 
-	return `- ${statusIcon} ${slackMetricLabels[field.key]} ${formatRawInteger(field.nextValue)}${slackMetricUnits[field.key]}${delta}`;
+const formatSlackDisplayField = (field: OrganizationStatsFieldSummary): string => {
+	const statusIcon = field.displayChanged ? '🟡' : '🟢';
+	const displayValue = field.displayChanged
+		? `${field.previousDisplayValue} → ${field.nextDisplayValue}`
+		: `${field.nextDisplayValue}（変更なし）`;
+
+	return `- ${statusIcon} ${slackMetricLabels[field.key]} ${displayValue}`;
 };
 
 const formatFailedStepsDetail = (failedSteps: string[]): string =>
@@ -274,7 +273,7 @@ const getSlackSummaryLabel = (
 	}
 
 	if (summary.status === 'updated') {
-		return `${summary.fields.filter((field) => field.changed).length}件更新`;
+		return `${summary.fields.filter((field) => field.displayChanged).length}件更新`;
 	}
 
 	return '更新なし';
@@ -295,12 +294,14 @@ const createSlackSummaryParts = (
 		options.mainBranchUpdate ? formatMainBranchUpdate(options.mainBranchUpdate) : undefined,
 		options.productionPromotion ? formatProductionPromotion(options.productionPromotion) : undefined
 	].filter((line): line is string => line !== undefined);
-	const metricRows =
+	const statisticRows =
 		summary.status === 'error'
 			? []
-			: getOrderedSlackFields(summary).map((field) =>
-					formatSlackMetricField(field, summary.shouldPersist)
-				);
+			: getOrderedSlackFields(summary).map((field) => formatSlackStatisticField(field));
+	const displayRows =
+		summary.status === 'error'
+			? []
+			: getOrderedSlackFields(summary).map((field) => formatSlackDisplayField(field));
 	const persistDecision = summary.status === 'error' ? undefined : formatPersistDecision(summary);
 
 	if (summary.status === 'error') {
@@ -317,7 +318,8 @@ const createSlackSummaryParts = (
 		title,
 		generatedAtLine: `生成: ${generatedAt.toISOString()}`,
 		summaryText: summaryLines.join('\n'),
-		metricRows,
+		statisticRows,
+		displayRows,
 		persistDecision,
 		runLink: options.runUrl ? `<${options.runUrl}|実行ログ>` : undefined
 	};
@@ -355,8 +357,8 @@ export const summarizeOrganizationStatsUpdate = (
 
 	const persistReasons: OrganizationStatsPersistReason[] = [];
 
-	if (hasOrganizationStatsDisplayChange(current, next)) {
-		persistReasons.push('display_change');
+	if (fields.some((field) => field.changed)) {
+		persistReasons.push('stats_change');
 	}
 
 	if (!current.youtubeSubscriberCountVerified) {
@@ -364,7 +366,7 @@ export const summarizeOrganizationStatsUpdate = (
 	}
 
 	return {
-		status: fields.some((field) => field.changed) ? 'updated' : 'no_change',
+		status: fields.some((field) => field.displayChanged) ? 'updated' : 'no_change',
 		fields,
 		shouldPersist: shouldPersistOrganizationStats(current, next),
 		persistReasons
@@ -382,7 +384,7 @@ export const getOrganizationStatsSlackColor = (
 		return 'danger';
 	}
 
-	if (summary.status === 'updated' && summary.shouldPersist) {
+	if (summary.status === 'updated') {
 		return 'warning';
 	}
 
@@ -396,8 +398,12 @@ export const formatOrganizationStatsSlackSummary = (
 	const parts = createSlackSummaryParts(summary, options);
 	const lines = [parts.title, parts.generatedAtLine, '---', parts.summaryText.replaceAll('*', '')];
 
-	if (parts.metricRows.length > 0) {
-		lines.push(...parts.metricRows);
+	if (parts.statisticRows.length > 0) {
+		lines.push('統計データ（前回取得値との差分）', ...parts.statisticRows);
+	}
+
+	if (parts.displayRows.length > 0) {
+		lines.push('表示データ（HP表示値）', ...parts.displayRows);
 	}
 
 	if (parts.persistDecision) {
@@ -423,8 +429,14 @@ export const formatOrganizationStatsSlackPayload = (
 		createSectionBlock(parts.summaryText)
 	];
 
-	if (parts.metricRows.length > 0) {
-		blocks.push(createSectionBlock(parts.metricRows.join('\n')));
+	if (parts.statisticRows.length > 0) {
+		blocks.push(
+			createSectionBlock(`*統計データ（前回取得値との差分）*\n${parts.statisticRows.join('\n')}`)
+		);
+	}
+
+	if (parts.displayRows.length > 0) {
+		blocks.push(createSectionBlock(`*表示データ（HP表示値）*\n${parts.displayRows.join('\n')}`));
 	}
 
 	if (parts.persistDecision) {


### PR DESCRIPTION
## Summary
- Split the organization stats Slack summary into raw statistic data and website display data sections.
- Make summary status and status markers depend only on website display value changes.
- Persist raw statistic changes so the next run can report deltas from the previous fetch.
- Use the JST execution date as the summary date instead of subtracting one day.

## Why
The previous summary mixed raw statistic changes with website display changes, which made the status inconsistent with whether the public homepage actually changed.

## Validation
- `node --check` on the changed source and test files.
- Direct Node-based checks for raw-only and display-changing summary cases.
- Workflow scripts reached their expected missing-env guards.
- `npm run precommit` could not be run locally because `npm` is not available on this Codex session PATH.