### PR TITLE
chore: 第17回定期演奏会の挟み込み募集を終了

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,12 @@ const flyerInsertionData: Parameters<typeof getFlyerInsertionStatus> = [
 const flyerInsertionData: Parameters<typeof getFlyerInsertionStatus> = [
 	{
 		concertSlug: 'regular-99',
-		status: 'recruitmentClosed'
+		status: 'onlyRecruitmentClosed'
 	}
 ];
 ```
+
+置きチラシを含むすべての募集を終了する場合は、`status` に `allClosed` を指定します。
 
 詳細な仕様は同ファイル内に記載してあります。
 

--- a/src/routes/contact/+page.server.ts
+++ b/src/routes/contact/+page.server.ts
@@ -4,7 +4,7 @@ import { getConcertBySlug, isFinished } from '$lib/concerts/utils';
 export const load: PageServerLoad = async () => {
 	const flyerInsertionData: Parameters<typeof getFlyerInsertionStatus> = [
 		{
-			concertSlug: 'regular-15',
+			concertSlug: 'regular-17',
 			status: 'onlyRecruitmentClosed'
 		}
 	];


### PR DESCRIPTION
## 概要

第17回定期演奏会のフライヤー挟み込み募集を終了状態へ切り替えます。

- 挟み込み案内の対象を `regular-15` から `regular-17` へ更新
- 状態を `onlyRecruitmentClosed` とし、挟み込み募集終了の案内を表示
- 置きチラシの募集は引き続き受け付ける案内を維持
- README のメンテナンス例を現行の状態名へ修正し、すべての募集を終了する `allClosed` も追記

## 背景・影響

第17回定期演奏会の挟み込み受付終了に伴う定期メンテナンスです。お問い合わせページでは募集終了のお知らせが表示され、置きチラシについては引き続き問い合わせできます。演奏会終了後は既存ロジックにより案内が自動的に非表示になります。

## 検証

- `npm run precommit`
  - Svelte check: 0 errors（既知の3 warnings）
  - Prettier / ESLint: pass
  - Vitest: 82 tests passed
- `npm run build`: pass（同じ既知の3 warnings）
- ローカルSSRで `onlyRecruitmentClosed` / `第17回定期演奏会` の表示データを確認
